### PR TITLE
Add ComponentSets to SceneNode and NodeType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -799,6 +799,7 @@ declare global {
     SliceNode |
     FrameNode |
     GroupNode |
+    ComponentSetNode |
     ComponentNode |
     InstanceNode |
     BooleanOperationNode |
@@ -816,6 +817,7 @@ declare global {
     "SLICE" |
     "FRAME" |
     "GROUP" |
+    "COMPONENT_SET" |
     "COMPONENT" |
     "INSTANCE" |
     "BOOLEAN_OPERATION" |


### PR DESCRIPTION
Looks like this was missed in the previous MR addressing variants (https://github.com/figma/plugin-typings/pull/10)

I ran into this while writing some code that acts on nodes based on their types. The type string for `ComponentSet`s is not available.

This PR is based on a very shallow understanding of the typings file and the changes made by the previous PR, as such I might've missed something important. Feel free to point out any improvements I should make and I'll try to get those in!