### PR TITLE
Update typings for interactive component navigation type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -437,7 +437,7 @@ declare global {
       readonly delay: number
     }
 
-  type Navigation = "NAVIGATE" | "SWAP" | "OVERLAY" | "SCROLL_TO"
+  type Navigation = "NAVIGATE" | "SWAP" | "OVERLAY" | "SCROLL_TO" | "CHANGE_TO"
 
   interface Easing {
     readonly type: "EASE_IN" | "EASE_OUT" | "EASE_IN_AND_OUT" | "LINEAR"


### PR DESCRIPTION
Adds the CHANGE_TO navigation type, new for interactive components. Reactions are still read-only