### PR TITLE
FigJam plugins: define typings for opaque nodes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,9 @@ declare global {
     createComponent(): ComponentNode
     createPage(): PageNode
     createSlice(): SliceNode
+    createSticky(): StickyNode
+    createConnector(): ConnectorNode
+    createShapeWithText(): ShapeWithTextNode
     /**
      * [DEPRECATED]: This API often fails to create a valid boolean operation. Use figma.union, figma.subtract, figma.intersect and figma.exclude instead.
      */
@@ -672,6 +675,21 @@ declare global {
     FramePrototypingMixin,
     ReactionMixin {}
 
+  interface OpaqueNodeMixin  {
+    readonly id: string
+    readonly absoluteTransform: Transform
+    relativeTransform: Transform
+    x: number
+    y: number
+    readonly width: number
+    readonly height: number
+    readonly removed: boolean
+    remove(): void
+    readonly parent: (BaseNode & ChildrenMixin) | null
+    name: string
+    toString(): string
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
   // Nodes
 
@@ -844,6 +862,18 @@ declare global {
     booleanOperation: "UNION" | "INTERSECT" | "SUBTRACT" | "EXCLUDE"
 
     expanded: boolean
+  }
+
+  interface StickyNode extends OpaqueNodeMixin {
+    readonly type: "STICKY"
+  }
+
+  interface ConnectorNode extends OpaqueNodeMixin {
+    readonly type: "CONNECTOR"
+  }
+
+  interface ShapeWithTextNode extends OpaqueNodeMixin {
+    readonly type: "SHAPE_WITH_TEXT"
   }
 
   type BaseNode =

--- a/index.d.ts
+++ b/index.d.ts
@@ -895,7 +895,10 @@ declare global {
     EllipseNode |
     PolygonNode |
     RectangleNode |
-    TextNode
+    TextNode |
+    StickyNode |
+    ConnectorNode |
+    ShapeWithTextNode
 
   type NodeType =
     "DOCUMENT" |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma/plugin-typings",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {


### PR DESCRIPTION
Users can create figjam nodes and access [opaque node properties](https://github.com/figma/figma/blob/master/web/js/figma_app/plugin/jsvm_public_node.ts#L53) if they have the feature flag `figjam_plugins`. With this version of @figma/plugin-typings users get TS support for FJ nodes.

Demo:
<img width="610" alt="Screen Shot 2021-06-16 at 7 14 32 AM" src="https://user-images.githubusercontent.com/1294344/122237683-5e62e600-ce74-11eb-9fe0-1462509813ce.png">
<img width="746" alt="Screen Shot 2021-06-16 at 7 17 21 AM" src="https://user-images.githubusercontent.com/1294344/122237686-5efb7c80-ce74-11eb-9805-c043a83454ac.png">

Fixes: https://app.asana.com/0/1200375790857146/1200273536464412
