### PR TITLE
add 'error' field to NotificationOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ declare global {
 
   interface NotificationOptions {
     timeout?: number
+    error?: boolean
   }
 
   interface NotificationHandler {


### PR DESCRIPTION
Callign notify with `{error:true}` makes the notification show up with
a red error background.