### PR TITLE
Change type for `ParameterValues` to `any`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Figma Plugin API version 1, update 29
+// Figma Plugin API version 1, update 30
 
 declare global {
   // Global variable with Figma's plugin API.

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare global {
   }
 
   interface ParameterValues {
-    [key: string]: string
+    [key: string]: any
   }
 
   interface SuggestionResults {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma/plugin-typings",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {


### PR DESCRIPTION
This is more generic and allows us to modify `ParameterValues` in the future without breaking the API.