### PR TITLE
console API types and tsconfig.json

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare global {
   const __uiFiles__: {
     [key: string]: string
   }
+  const console: Console
 
   interface PluginAPI {
     readonly apiVersion: "1.0.0"
@@ -966,6 +967,18 @@ declare global {
     readonly hash: string
     getBytesAsync(): Promise<Uint8Array>
   }
+
+  // The plugin environment exposes the browser console API,
+  // so expected calls like console.log() still work.
+  interface Console {
+    log(message?: any, ...optionalParams: any[]): void
+    error(message?: any, ...optionalParams: any[]): void
+    assert(condition?: boolean, message?: string, ...data: any[]): void
+    info(message?: any, ...optionalParams: any[]): void
+    warn(message?: any, ...optionalParams: any[]): void
+    clear(): void
+  }
+
   } // declare global
 
   export {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    // Figma plugins run in an environment with es6 but no browser symbols.
+    "lib": ["es6"],
+    "noEmit": true,
+    "strict": true,
+  }
+}


### PR DESCRIPTION
Figma plugins run in a restricted environment where the browser APIs
aren't available by default, including 'console'.  This means the plugin
typings should declare exactly what console API is available.  (Note that
the functions listed here are a subset of the full browser console API;
these are the subset that plugins actually have access to.)

This change also adds a tsconfig.json to this repo, because otherwise
TypeScript thinks this definition of console conflicts with the ambient
browser one.