### PR TITLE
add event param back

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,9 +37,9 @@ declare global {
     readonly root: DocumentNode
     currentPage: PageNode
 
-    on(type: EventType, callback: () => void): void
-    once(type: EventType, callback: () => void): void
-    off(type: EventType, callback: () => void): void
+    on(type: EventType, callback: (event?: RunEvent) => void): void
+    once(type: EventType, callback: (event?: RunEvent) => void): void
+    off(type: EventType, callback: (event?: RunEvent) => void): void
 
     readonly mixed: unique symbol
 


### PR DESCRIPTION
Add `event` param back. This bug was introduced in [this change](https://github.com/figma/plugin-typings/commit/5604eefdbdf6671937bf65e496251644c168893f#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8L35-L37) which clobbered [this change](https://github.com/figma/plugin-typings/commit/08b12fe58bd28a8c4905d47463929faa53a45392)

We had a long-standing PR that added `EventType`, but in doing so inadvertently removed `event` param from the callback function

We had a bug report of this at https://github.com/figma/plugin-typings/issues/53