### PR TITLE
add text range functions again

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -797,6 +797,10 @@ declare global {
     setRangeTextStyleId(start: number, end: number, value: string): void
     getRangeFillStyleId(start: number, end: number): string | PluginAPI['mixed']
     setRangeFillStyleId(start: number, end: number, value: string): void
+    getRangeListOptions(start: number, end: number): TextListOptions | PluginAPI['mixed']
+    setRangeListOptions(start: number, end: number, value: TextListOptions): void
+    getRangeIndentation(start: number, end: number): number | PluginAPI['mixed']
+    setRangeIndentation(start: number, end: number, value: number): void
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma/plugin-typings",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {


### PR DESCRIPTION
Fix bad merge conflict caused by [this](https://github.com/figma/plugin-typings/commit/5604eefdbdf6671937bf65e496251644c168893f) clobbering [this](https://github.com/figma/plugin-typings/commit/0d32751)

I checked the rest of the big diff earlier and this is the last change that was affected