### PR TITLE
use tsconfig for npm test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {
-    "test": "tsc --noEmit --strict --typeRoots '[]' index.d.ts"
+    "test": "tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change `npm test` to run tsc with no arguments, so it picks up the local
tsconfig.json.  In particular this makes it obey the 'lib' setting found
there.  (Currently `npm test` fails due to this.)