### PR TITLE
add timeout-related API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1076,6 +1076,10 @@ declare global {
     warn(message?: any, ...optionalParams: any[]): void
     clear(): void
   }
+  function setTimeout(callback: Function, timeout: number): number;
+  function clearTimeout(handle: number): void;
+  function setInterval(callback: Function, timeout: number): number;
+  function clearInterval(handle: number): void;
 
   type HexCode = string
 


### PR DESCRIPTION
Much like the console API, we support a subset of the functionality that a browser
exposes.