### PR TITLE
Replace const with var for console declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,9 @@ declare global {
   const __uiFiles__: {
     [key: string]: string
   }
-  const console: Console
+
+  // Using var so TypeScript can merge this with @types/node and "lib": ["DOM"]
+  var console: Console
 
   type EventType = "selectionchange" | "currentpagechange" | "close" | "timerstart" | "timerstop" | "timerpause" | "timerresume" | "timeradjust" | "timerdone" | "run"
 


### PR DESCRIPTION
This will allow the typings to be used with "lib": ["DOM"] or @types/node.

```json
{
  "compilerOptions": {
    "lib": ["DOM", "ESNext"],
    "typeRoots": ["./node_modules/@types", "./node_modules/@figma"]
  }
}
```

Before it was failing with this error message:

```
Cannot redeclare block-scoped variable 'console'.
```