### PR TITLE
Add full set of Easing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -529,7 +529,7 @@ declare global {
   type Navigation = "NAVIGATE" | "SWAP" | "OVERLAY" | "SCROLL_TO" | "CHANGE_TO"
 
   interface Easing {
-    readonly type: "EASE_IN" | "EASE_OUT" | "EASE_IN_AND_OUT" | "LINEAR"
+    readonly type: "EASE_IN" | "EASE_OUT" | "EASE_IN_AND_OUT" | "LINEAR" | 'EASE_IN_BACK' | 'EASE_OUT_BACK' | 'EASE_IN_AND_OUT_BACK' | 'CUSTOM_CUBIC_BEZIER'
     readonly easingFunctionCubicBezier?: EasingFunctionBezier
   }
 


### PR DESCRIPTION
Add missing `EASE_IN_BACK`, `EASE_OUT_BACK`, `EASE_IN_AND_OUT_BACK`, `CUSTOM_CUBIC_BEZIER` easing types as documented here: https://www.figma.com/plugin-docs/api/Transition/#docsNav

Addresses: https://github.com/figma/plugin-typings/issues/20