### PR TITLE
Fix plugin api types reference for VSCode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // Figma Plugin API version 1, update 39
-/// <reference path="./plugin-api" />
+/// <reference types="./plugin-api" />
 
 declare global {
   // Global variable with Figma's plugin API.


### PR DESCRIPTION
VSCode is unable to locate Plugin API typings, here is a quick fix. 
 
<img width="649" alt="Screenshot 2021-11-13 at 23 55 36" src="https://user-images.githubusercontent.com/8017482/141658870-2f3d89f5-a136-4642-8f83-b2ac0fec0637.png">
