### PR TITLE
Fix typing bug where we declared DropFile functions as properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma/plugin-typings",
-  "version": "1.41.0",
+  "version": "1.42.1",
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -245,8 +245,8 @@ interface DropItem {
 interface DropFile {
   name: string
   type: string
-  getBytesAsync: Promise<Uint8Array>
-  getTextAsync: Promise<string>
+  getBytesAsync(): Promise<Uint8Array>
+  getTextAsync(): Promise<string>
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `getBytesAsync` and `getTextAsync` functions in the `DropFile` interface in the plugin API were incorrectly declared as properties when they are actually supposed to be functions. This PR fixes the typings.