### PR TITLE
Add CIRCLE_FILLED connector stroke cap type

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -705,6 +705,7 @@ type ConnectorStrokeCap =
   | 'ARROW_LINES'
   | 'TRIANGLE_FILLED'
   | 'DIAMOND_FILLED'
+  | 'CIRCLE_FILLED'
 
 ////////////////////////////////////////////////////////////////////////////////
 // Mixins


### PR DESCRIPTION
Sibling PR of https://github.com/figma/figma/pull/63122.

This PR adds the `CIRCLE_FILLED` option to the `ConnectorStrokeCap` type, to support the new circle end cap added in https://github.com/figma/figma/pull/63058.

I don't plan on merging this PR until close to when we flip the circle endcap feature flag on for everyone, which shouldn't be until at least 4/13/22