### PR TITLE
Use union type to indicate the getStyleById return type

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -43,7 +43,7 @@ interface PluginAPI {
   readonly parameters: ParametersAPI
 
   getNodeById(id: string): BaseNode | null
-  getStyleById(id: string): BaseStyle | null
+  getStyleById(id: string): TextStyle | PaintStyle | EffectStyle | GridStyle | null
 
   readonly root: DocumentNode
   currentPage: PageNode


### PR DESCRIPTION
this change will bring better type experience in bellow case

```ts
const style = figma.getStyleById(styleId)

if (style.type === 'TEXT') {
  // TS would infer `style` is `TextStyle` type here
} else if (style.type === 'PAINT') {
  // TS would infer `style` is `GridStyle` type here
}
``` 