### PR TITLE
Update types for Component Properties support

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -743,10 +743,10 @@ interface SceneNodeMixin {
   locked: boolean
   stuckNodes: SceneNode[]
   componentPropertyReferences:
-  | {
-      [nodeProperty in 'visible' | 'characters' | 'mainComponent']: string
-    }
-  | null
+    | {
+        [nodeProperty in 'visible' | 'characters' | 'mainComponent']: string
+      }
+    | null
 }
 
 interface StickableMixin {
@@ -974,10 +974,9 @@ interface ComponentPropertiesMixin {
   ): string
   editComponentProperty(
     propertyName: string,
-    newValue: { name?: string; defaultValue?: string | boolean},
+    newValue: { name?: string; defaultValue?: string | boolean },
   ): string
   deleteComponentProperty(propertyName: string): void
-
 }
 
 interface TextSublayerNode extends MinimalFillsMixin {
@@ -1167,14 +1166,18 @@ type ComponentPropertyDefinitions = {
   }
 }
 
-interface ComponentSetNode extends BaseFrameMixin, PublishableMixin, ComponentPropertiesMixin{
+interface ComponentSetNode extends BaseFrameMixin, PublishableMixin, ComponentPropertiesMixin {
   readonly type: 'COMPONENT_SET'
   clone(): ComponentSetNode
   readonly defaultVariant: ComponentNode
   readonly variantGroupProperties: { [property: string]: { values: string[] } }
 }
 
-interface ComponentNode extends DefaultFrameMixin, PublishableMixin, VariantMixin, ComponentPropertiesMixin{
+interface ComponentNode
+  extends DefaultFrameMixin,
+    PublishableMixin,
+    VariantMixin,
+    ComponentPropertiesMixin {
   readonly type: 'COMPONENT'
   clone(): ComponentNode
   createInstance(): InstanceNode

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -742,6 +742,11 @@ interface SceneNodeMixin {
   visible: boolean
   locked: boolean
   stuckNodes: SceneNode[]
+  componentPropertyReferences:
+  | {
+      [nodeProperty in 'visible' | 'characters' | 'mainComponent']: string
+    }
+  | null
 }
 
 interface StickableMixin {
@@ -960,6 +965,21 @@ interface VariantMixin {
   readonly variantProperties: { [property: string]: string } | null
 }
 
+interface ComponentPropertiesMixin {
+  readonly componentPropertyDefinitions: ComponentPropertyDefinitions
+  addComponentProperty(
+    propertyName: string,
+    type: ComponentPropertyType,
+    defaultValue: string | boolean,
+  ): string
+  editComponentProperty(
+    propertyName: string,
+    newValue: { name?: string; defaultValue?: string | boolean},
+  ): string
+  deleteComponentProperty(propertyName: string): void
+
+}
+
 interface TextSublayerNode extends MinimalFillsMixin {
   readonly hasMissingFont: boolean
 
@@ -1137,17 +1157,34 @@ interface TextNode extends DefaultShapeMixin, ConstraintMixin, TextSublayerNode 
   textStyleId: string | PluginAPI['mixed']
 }
 
-interface ComponentSetNode extends BaseFrameMixin, PublishableMixin {
+type ComponentPropertyType = 'BOOLEAN' | 'TEXT' | 'INSTANCE_SWAP' | 'VARIANT'
+
+type ComponentPropertyDefinitions = {
+  [propertyName: string]: {
+    type: ComponentPropertyType
+    defaultValue: string | boolean
+    variantOptions?: string[]
+  }
+}
+
+interface ComponentSetNode extends BaseFrameMixin, PublishableMixin, ComponentPropertiesMixin{
   readonly type: 'COMPONENT_SET'
   clone(): ComponentSetNode
   readonly defaultVariant: ComponentNode
   readonly variantGroupProperties: { [property: string]: { values: string[] } }
 }
 
-interface ComponentNode extends DefaultFrameMixin, PublishableMixin, VariantMixin {
+interface ComponentNode extends DefaultFrameMixin, PublishableMixin, VariantMixin, ComponentPropertiesMixin{
   readonly type: 'COMPONENT'
   clone(): ComponentNode
   createInstance(): InstanceNode
+}
+
+type ComponentProperties = {
+  [propertyName: string]: {
+    type: ComponentPropertyType
+    value: string | boolean
+  }
 }
 
 interface InstanceNode extends DefaultFrameMixin, VariantMixin {
@@ -1155,7 +1192,8 @@ interface InstanceNode extends DefaultFrameMixin, VariantMixin {
   clone(): InstanceNode
   mainComponent: ComponentNode | null
   swapComponent(componentNode: ComponentNode): void
-  setProperties(properties: { [property: string]: string }): void
+  setProperties(properties: { [propertyName: string]: string | boolean }): void
+  readonly componentProperties: ComponentProperties
   detachInstance(): FrameNode
   scaleFactor: number
 }


### PR DESCRIPTION
Types have been updated to match changes to the plugin API documentation for component properties [here](https://github.com/figma/figma/pull/71474). Here is the [paper doc](https://paper.dropbox.com/doc/Component-Props-Finalize-API-Documentation--Bj61Yhzh26znUSCZUYys8~UmAg-X5fZlCf7ZzFykLr6JJ1oW) for changes being made to the documentation. 

Confirmed that running the tests in `/plugin-docs/tests` passes with these new types but will hold on merging this PR until the PR linked above is finalized and approved (but not merged).