### PR TITLE
Rename LayerSublayerNode (with typo) to LabelSublayerNode

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1287,14 +1287,14 @@ interface CodeBlockNode extends OpaqueNodeMixin, MinimalBlendMixin {
   clone(): CodeBlockNode
 }
 
-interface LayerSublayerNode {
+interface LabelSublayerNode {
   fills: Paint[] | PluginAPI['mixed']
 }
 
 interface ConnectorNode extends OpaqueNodeMixin, MinimalBlendMixin, MinimalStrokesMixin {
   readonly type: 'CONNECTOR'
   readonly text: TextSublayerNode
-  readonly textBackground: LayerSublayerNode
+  readonly textBackground: LabelSublayerNode
   readonly cornerRadius?: number
   connectorLineType: 'ELBOWED' | 'STRAIGHT'
   connectorStart: ConnectorEndpoint


### PR DESCRIPTION
Fix typo in LayerSublayerNode interface name