### PR TITLE
Add attachedConnectors field for SceneNode

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -741,7 +741,8 @@ interface PluginDataMixin {
 interface SceneNodeMixin {
   visible: boolean
   locked: boolean
-  stuckNodes: SceneNode[]
+  readonly stuckNodes: SceneNode[]
+  readonly attachedConnectors: ConnectorNode[]
   componentPropertyReferences:
     | {
         [nodeProperty in 'visible' | 'characters' | 'mainComponent']: string


### PR DESCRIPTION
This adds attachedConnectors for SceneNode which returns an array of connectors that are attached to a node.

Note that while doing this I also realized that stuckNodes should be `readonly`, so I updated that as well.