### PR TITLE
Add Bash language to code block enum

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1287,6 +1287,7 @@ interface CodeBlockNode extends OpaqueNodeMixin, MinimalBlendMixin {
     | 'SWIFT'
     | 'KOTLIN'
     | 'RUST'
+    | 'BASH'
   clone(): CodeBlockNode
 }
 


### PR DESCRIPTION
Bash is now supported as a code block language.