### PR TITLE
Added button and onDequeue typings for notify

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -180,7 +180,14 @@ interface ClientStorageAPI {
 interface NotificationOptions {
   timeout?: number
   error?: boolean
+  onDequeue?: (reason: VisualBellDequeueReason) => void
+  button?: {
+    text: string
+    action: () => boolean | void
+  }
 }
+
+type VisualBellDequeueReason = 'timeout' | 'dismiss' | 'action_button_click'
 
 interface NotificationHandler {
   cancel: () => void

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -180,14 +180,14 @@ interface ClientStorageAPI {
 interface NotificationOptions {
   timeout?: number
   error?: boolean
-  onDequeue?: (reason: VisualBellDequeueReason) => void
+  onDequeue?: (reason: NotifyDequeueReason) => void
   button?: {
     text: string
     action: () => boolean | void
   }
 }
 
-type VisualBellDequeueReason = 'timeout' | 'dismiss' | 'action_button_click'
+type NotifyDequeueReason = 'timeout' | 'dismiss' | 'action_button_click'
 
 interface NotificationHandler {
   cancel: () => void

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -82,7 +82,7 @@ function testNotify() {
   })
 
   figma.notify("onDequeue", {
-    onDequeue: (reason: VisualBellDequeueReason) => {
+    onDequeue: (reason: NotifyDequeueReason) => {
       switch (reason) {
         case 'timeout':
           break;

--- a/test-usage.sh
+++ b/test-usage.sh
@@ -60,6 +60,47 @@ function testFn1(node: SceneNode): node is FrameNode {
 function testFn(paint: SolidPaint | GradientPaint | ImagePaint | null): boolean {
   return !!paint
 }
+
+function testNotify() {
+  figma.notify("normal")
+  figma.notify("error", {error: true})
+  figma.notify("timeout", {timeout: 10000})
+  figma.notify("Infinity", {timeout: Infinity})
+
+  figma.notify("button", {button: {
+    text: "button",
+    action: () => {
+      return false
+    }
+  }})
+
+  figma.notify("button", {
+    button: {
+      text: "button",
+      action: () => {},
+    }
+  })
+
+  figma.notify("onDequeue", {
+    onDequeue: (reason: VisualBellDequeueReason) => {
+      switch (reason) {
+        case 'timeout':
+          break;
+        case 'dismiss':
+          break;
+        case 'action_button_click':
+          break;
+        default:
+          function assertNever(x: never): never {
+            throw new Error("Unexpected object: " + x);
+          }
+          assertNever(reason);
+          break;
+      }
+    }
+  })
+
+}
 EOF
 
 


### PR DESCRIPTION
This PR adds new parameters to the `notify` API. It adds `button`, `onDequeue`, and `NotifyDequeueReason`. The documentation changes are at: https://github.com/figma/figma/pull/73090 