### PR TITLE
Add strict: true to tsconfig.json in our tests

### DIFF
--- a/test-usage.sh
+++ b/test-usage.sh
@@ -15,6 +15,7 @@ cat > tsconfig.json << EOF
   "compilerOptions": {
     "target": "es6",
     "lib": ["es6"],
+    "strict": true,
     "typeRoots": [
       "./node_modules/@types",
       "./node_modules/@figma"


### PR DESCRIPTION
This makes sure that we test the same as our default plugin typings.