### PR TITLE
Add fontWeight to StyledTextSegment

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -587,6 +587,7 @@ interface StyledTextSegment {
   end: number
   fontSize: number
   fontName: FontName
+  fontWeight: number
   textDecoration: TextDecoration
   textCase: TextCase
   lineHeight: LineHeight


### PR DESCRIPTION
I can't find this in the Figma documentation page, but according to the implementation `fontWeight` is a supported property of `getStyledTextSegments`

eg.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/1330575/188329907-9e5b6e15-9d29-410a-8137-cb710a8b2378.png">