### PR TITLE
plugins: add plugin typings for getRangeFontWeight

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1002,6 +1002,7 @@ interface TextSublayerNode extends MinimalFillsMixin {
 
   fontSize: number | PluginAPI['mixed']
   fontName: FontName | PluginAPI['mixed']
+  readonly fontWeight: number | PluginAPI['mixed']
   textCase: TextCase | PluginAPI['mixed']
   textDecoration: TextDecoration | PluginAPI['mixed']
   letterSpacing: LetterSpacing | PluginAPI['mixed']

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1016,6 +1016,7 @@ interface TextSublayerNode extends MinimalFillsMixin {
   setRangeFontSize(start: number, end: number, value: number): void
   getRangeFontName(start: number, end: number): FontName | PluginAPI['mixed']
   setRangeFontName(start: number, end: number, value: FontName): void
+  getRangeFontWeight(start: number, end: number): number | PluginAPI['mixed']
   getRangeAllFontNames(start: number, end: number): FontName[]
   getRangeTextCase(start: number, end: number): TextCase | PluginAPI['mixed']
   setRangeTextCase(start: number, end: number, value: TextCase): void


### PR DESCRIPTION
https://github.com/figma/plugin-typings/pull/148 added types for `fontWeight` to `StyledTextSegment` but we also added `getRangeFontWeight` so adding types for this as well - implementation here: https://github.com/figma/figma/pull/74934

Test Plan
- assert that the types match those for the implementation