### PR TITLE
plugins: add exposed instance properties to API typings

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1220,6 +1220,8 @@ interface InstanceNode extends DefaultFrameMixin, VariantMixin {
   readonly componentProperties: ComponentProperties
   detachInstance(): FrameNode
   scaleFactor: number
+  readonly exposedInstances: InstanceNode[]
+  isExposedInstance: boolean
 }
 
 interface BooleanOperationNode extends DefaultShapeMixin, ChildrenMixin, CornerMixin {


### PR DESCRIPTION
Update the typings in `InstanceNode` to expect `exposedInstances` and `isExposedInstance` properties. Changes added here: https://github.com/figma/figma/pull/82869 and https://github.com/figma/figma/pull/82049