### PR TITLE
plugins: change StyledTextSegment fontWeight to readonly

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -587,7 +587,7 @@ interface StyledTextSegment {
   end: number
   fontSize: number
   fontName: FontName
-  fontWeight: number
+  readonly fontWeight: number
   textDecoration: TextDecoration
   textCase: TextCase
   lineHeight: LineHeight


### PR DESCRIPTION
This field should be marked as readonly to match the plugin API.