### PR TITLE
Add createNodeFromJSXAsync

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,18 @@ declare global {
     arrayBuffer(): Promise<ArrayBuffer>
     text(): Promise<string>
   }
+
+  type FigmaVirtualNode<T> = { __type: T }
+
+  type FigmaDeclarativeChildren<T> =
+    | FigmaVirtualNode<T>
+    | FigmaDeclarativeChildren<T>[]
+    | string
+    | null
+    | undefined
+    | false
+
+  type FigmaDeclarativeNode = FigmaDeclarativeChildren<any>
 } // declare global
 
 export {}

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -78,6 +78,8 @@ interface PluginAPI {
   createShapeWithText(): ShapeWithTextNode
   createCodeBlock(): CodeBlockNode
   createSection(): SectionNode
+  createNodeFromJSXAsync(jsx: FigmaDeclarativeNode): Promise<SceneNode>
+
   /**
    * [DEPRECATED]: This API often fails to create a valid boolean operation. Use figma.union, figma.subtract, figma.intersect and figma.exclude instead.
    */


### PR DESCRIPTION
This adds typings for `createNodeFromJSXAsync`

I ended up porting the types for `FigmaDeclarativeNode` into plugin-typings since they are very small and haven't really changed since we have released widgets, so it should be easy to just ask people to install the widget typings if they want to use the components from the JSX api