### PR TITLE
Update typings for addComponentProperty

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -981,7 +981,7 @@ interface ComponentPropertiesMixin {
   readonly componentPropertyDefinitions: ComponentPropertyDefinitions
   addComponentProperty(
     propertyName: string,
-    type: ComponentPropertyType,
+    type: Exclude<ComponentPropertyType, 'VARIANT'>,
     defaultValue: string | boolean,
     options?: ComponentPropertyOptions,
   ): string


### PR DESCRIPTION
`AddComponentProperty` does not support type: 'VARIANT' so lets update the type to reflect that:

See: https://www.figma.com/plugin-docs/api/node-properties#addcomponentproperty