### PR TITLE
Renamed createVideo to createVideoAsync

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -123,7 +123,7 @@ interface PluginAPI {
   createImage(data: Uint8Array): Image
   getImageByHash(hash: string): Image | null
 
-  createVideo(data: Uint8Array): Video
+  createVideo(data: Uint8Array): Promise<Video>
 
   createLinkPreviewAsync(url: string): Promise<EmbedNode | LinkUnfurlNode>
 

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -123,7 +123,7 @@ interface PluginAPI {
   createImage(data: Uint8Array): Image
   getImageByHash(hash: string): Image | null
 
-  createVideo(data: Uint8Array): Promise<Video>
+  createVideoAsync(data: Uint8Array): Promise<Video>
 
   createLinkPreviewAsync(url: string): Promise<EmbedNode | LinkUnfurlNode>
 


### PR DESCRIPTION
This change renames `createVideo(...): Video` to `createVideoAsync(...): Promise<Video>`.