### PR TITLE
Update strokeWeight return to include mixed

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1050,7 +1050,7 @@ type HandleMirroring = 'NONE' | 'ANGLE' | 'ANGLE_AND_LENGTH'
 interface MinimalStrokesMixin {
   strokes: ReadonlyArray<Paint>
   strokeStyleId: string
-  strokeWeight: number
+  strokeWeight: number | PluginAPI['mixed']
   strokeJoin: StrokeJoin | PluginAPI['mixed']
   strokeAlign: 'CENTER' | 'INSIDE' | 'OUTSIDE'
   dashPattern: ReadonlyArray<number>


### PR DESCRIPTION
I'll be enabling `ee_ind_borders_plugin_api` soon which makes `strokeWeight` return mixed if individual stroke weight values are used per side. This updates the plugin typings to reflect this.

Related docs change: https://github.com/figma/figma/pull/77996