### PR TITLE
Add "ON_VIDEO_HIT" to Trigger type for plugin api

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -863,6 +863,7 @@ type Trigger =
       readonly device: 'KEYBOARD' | 'XBOX_ONE' | 'PS4' | 'SWITCH_PRO' | 'UNKNOWN_CONTROLLER'
       readonly keyCodes: ReadonlyArray<number>
     }
+  | { readonly type: 'ON_VIDEO_HIT'; readonly videoHitTime: number }
 
 type Navigation = 'NAVIGATE' | 'SWAP' | 'OVERLAY' | 'SCROLL_TO' | 'CHANGE_TO'
 


### PR DESCRIPTION
This PR makes the necessary API typing changes for https://github.com/figma/figma/pull/94362/files

We should not merge this PR until Videos V2 launch.