### PR TITLE
Add absoluteBoundingBox property to OpaqueNodeMixin

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1209,6 +1209,7 @@ interface OpaqueNodeMixin extends BaseNodeMixin, SceneNodeMixin, ExportMixin {
   y: number
   readonly width: number
   readonly height: number
+  readonly absoluteBoundingBox: Rect | null
 }
 
 interface MinimalBlendMixin {


### PR DESCRIPTION
This exposes the `absoluteBoundingBox` property to all nodes that extend `OpaqueNodeMixin`, such as sections, stickies, etc...