### PR TITLE
Add "SMALL_CAPS" and "SMALL_CAPS_FORCED" to `TextCase`

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -481,7 +481,13 @@ interface FontName {
   readonly family: string
   readonly style: string
 }
-declare type TextCase = 'ORIGINAL' | 'UPPER' | 'LOWER' | 'TITLE'
+declare type TextCase =
+  | 'ORIGINAL'
+  | 'UPPER'
+  | 'LOWER'
+  | 'TITLE'
+  | 'SMALL_CAPS'
+  | 'SMALL_CAPS_FORCED'
 declare type TextDecoration = 'NONE' | 'UNDERLINE' | 'STRIKETHROUGH'
 interface ArcData {
   readonly startingAngle: number


### PR DESCRIPTION
`TextCase` now supports `"SMALL_CAPS"` and `"SMALL_CAPS_FORCED"` too.