### PR TITLE
Make properties in componentPropertyReferences optional

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -891,7 +891,7 @@ interface SceneNodeMixin {
   readonly attachedConnectors: ConnectorNode[]
   componentPropertyReferences:
     | {
-        [nodeProperty in 'visible' | 'characters' | 'mainComponent']: string
+        [nodeProperty in 'visible' | 'characters' | 'mainComponent']?: string
       }
     | null
 }


### PR DESCRIPTION
The `visible`, `characters`, and `mainComponent` in `componentPropertyReferences` should be optional, not required.