### PR TITLE
adds PLAINTEXT to code block languages

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1453,6 +1453,7 @@ interface CodeBlockNode extends OpaqueNodeMixin, MinimalBlendMixin {
     | 'KOTLIN'
     | 'RUST'
     | 'BASH'
+    | 'PLAINTEXT'
   clone(): CodeBlockNode
 }
 interface LabelSublayerNode {


### PR DESCRIPTION
We added `PLAINTEXT` as a code block language some time ago, but didn't add it to plugin docs. Now that we're removing the feature flag for it on https://github.com/figma/figma/pull/136343, it's a good time to do it.