### PR TITLE
Typing for figma.payments REST API helper

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -162,6 +162,7 @@ interface PaymentsAPI {
     interstitial?: 'PAID_FEATURE' | 'TRIAL_ENDED' | 'SKIP'
   }): Promise<void>
   requestCheckout(): void
+  getPluginPaymentTokenAsync(): Promise<string>
 }
 interface ClientStorageAPI {
   getAsync(key: string): Promise<any | undefined>


### PR DESCRIPTION
Add `getPluginPaymentTokenAsync` to `payments` API.

## Testing plan
Following `plugin-docs/README.md` and ensured that `npm run test` returned `plugin-docs-api.d.ts matches plugin-typings.d.ts`