### PR TITLE
Add missing alv5 properties

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -999,6 +999,11 @@ declare type VariableBindableNodeField =
   | 'topRightRadius'
   | 'bottomLeftRadius'
   | 'bottomRightRadius'
+  | 'counterAxisSpacing'
+  | 'minWidth'
+  | 'maxWidth'
+  | 'minHeight'
+  | 'maxHeight'
 declare type VariableBindablePaintField = 'color'
 declare type VariableBindableComponentPropertyField = 'value'
 interface BoundVariableDescriptor {
@@ -1038,6 +1043,10 @@ interface DimensionAndPositionMixin {
   readonly absoluteBoundingBox: Rect | null
 }
 interface LayoutMixin extends DimensionAndPositionMixin {
+  minWidth: number
+  maxWidth: number
+  minHeight: number
+  maxHeight: number
   readonly absoluteRenderBounds: Rect | null
   constrainProportions: boolean
   rotation: number
@@ -1150,6 +1159,9 @@ interface BaseFrameMixin
     LayoutMixin,
     ExportMixin,
     IndividualStrokesMixin {
+  layoutWrap: 'NO_WRAP' | 'WRAP'
+  counterAxisSpacing: number
+  counterAxisAlignContent: 'AUTO' | 'SPACE_BETWEEN'
   layoutMode: 'NONE' | 'HORIZONTAL' | 'VERTICAL'
   primaryAxisSizingMode: 'FIXED' | 'AUTO'
   counterAxisSizingMode: 'FIXED' | 'AUTO'


### PR DESCRIPTION
Adding these to ensure type safety in native CSS codegen in Dev Mode that outputs flexbox rules for wrapping layouts.

**supports variables**
`minWidth`
`maxWidth`
`minHeight`
`maxHeight`
`counterAxisSpacing`
**other**
`layoutWrap`
`counterAxisAlignContent`

## Test plan
Used a local ambient typings file [in this PR](https://github.com/figma/figma/pull/143605) that implements the changes to native codegen, to ensure the types are correct
