### PR TITLE
color management - add document color profile to DocumentNode

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1194,6 +1194,7 @@ interface TextSublayerNode extends MinimalFillsMixin {
 interface DocumentNode extends BaseNodeMixin {
   readonly type: 'DOCUMENT'
   readonly children: ReadonlyArray<PageNode>
+  readonly documentColorProfile: 'LEGACY' | 'SRGB' | 'DISPLAY_P3'
   appendChild(child: PageNode): void
   insertChild(index: number, child: PageNode): void
   findChildren(callback?: (node: PageNode) => boolean): Array<PageNode>


### PR DESCRIPTION
With the new color management feature, `documentColorProfile` controls the color profile of the document.

Fixes: https://app.asana.com/0/1203469454724000/1204199932331876/f