### PR TITLE
StickyNode: add isWideWidth property

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1600,6 +1600,7 @@ interface StickyNode extends OpaqueNodeMixin, MinimalFillsMixin, MinimalBlendMix
   readonly text: TextSublayerNode
   authorVisible: boolean
   authorName: string
+  isWideWidth: boolean
   clone(): StickyNode
 }
 interface StampNode extends DefaultShapeMixin, ConstraintMixin, StickableMixin {


### PR DESCRIPTION
This change adds the `isWideWidth` property to the `StickyNode` type.