### PR TITLE
version bump to 1.70.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma/plugin-typings",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "Typings for the Figma Plugin API",
   "main": "",
   "scripts": {


### PR DESCRIPTION
This version includes the `StickyNode.isWideWidth` property.