### PR TITLE
Missing boundVariables for PaintStyle

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1888,6 +1888,9 @@ interface BaseStyle extends PublishableMixin, PluginDataMixin {
   remove(): void
 }
 interface PaintStyle extends BaseStyle {
+  readonly boundVariables?: {
+    [field in VariableBindablePaintField]?: VariableAlias
+  }
   type: 'PAINT'
   paints: ReadonlyArray<Paint>
 }


### PR DESCRIPTION
<img width="612" alt="image" src="https://github.com/figma/plugin-typings/assets/18498712/f26498ee-699b-49ac-9249-86ccc6ef376f">

<img width="485" alt="image" src="https://github.com/figma/plugin-typings/assets/18498712/1a3eb249-6327-41ef-8e6d-b1224a74aa37">
