### PR TITLE
Run npm run update-typings again to bring things back in sync

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -406,7 +406,6 @@ interface RunParametersEvent<ParametersType = ParameterValues | undefined> {
 }
 interface OpenDevResourcesEvent {
   command: 'open-dev-resource'
-  parameters?: undefined
   link: {
     url: string
     name: string


### PR DESCRIPTION
Sorry for another PR! looks like https://github.com/figma/figma/pull/167852 is still failing because the typings are still not in sync. I ran `npm run update-typings` again which removes a line that's not related to new shapes. Not sure if this is necessary anymore but this might need to be added back in in the future!