### PR TITLE
Add new CENTER magnet to plugin typings

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1359,7 +1359,7 @@ interface ConnectorEndpointPositionAndEndpointNodeId {
 }
 interface ConnectorEndpointEndpointNodeIdAndMagnet {
   endpointNodeId: string
-  magnet: 'NONE' | 'AUTO' | 'TOP' | 'LEFT' | 'BOTTOM' | 'RIGHT'
+  magnet: 'NONE' | 'AUTO' | 'TOP' | 'LEFT' | 'BOTTOM' | 'RIGHT' | 'CENTER'
 }
 declare type ConnectorEndpoint =
   | ConnectorEndpointPosition


### PR DESCRIPTION
Introducing a new `CENTER` magnet type for straight connectors.

plugin api code changes: https://github.com/figma/figma/pull/199413/files
doc updates: https://github.com/figma/figma/pull/186195

asana: https://app.asana.com/0/1204042327800635/1204207779283254