### PR TITLE
Fix deprecated createVariable call by using collection node

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1467,7 +1467,7 @@ interface SceneNodeMixin extends ExplicitVariableModesMixin {
     }
     readonly textRangeFills?: VariableAlias[]
   }
-  setBoundVariable(field: VariableBindableNodeField, variableId: string | null): void
+  setBoundVariable(field: VariableBindableNodeField, variable: Variable | null): void
   readonly inferredVariables?: {
     readonly [field in VariableBindableNodeField]?: VariableAlias[]
   } & {

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -172,7 +172,7 @@ interface VariablesAPI {
   getLocalVariableCollections(): VariableCollection[]
   createVariable(
     name: string,
-    collectionId: string,
+    collection: VariableCollection,
     resolvedType: VariableResolvedDataType,
   ): Variable
   createVariableCollection(name: string): VariableCollection


### PR DESCRIPTION
Solved: 

1. "Calling createVariable with a collection id is deprecated. Please pass the collection node instead."
2. "Calling setBoundVariable with a variable id is deprecated. Please pass the variable node instead."

https://github.com/figma/plugin-typings/issues/276
