### PR TITLE
[web] Fix missing properties in plugin-typings

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1548,6 +1548,7 @@ declare type VariableBindableNodeField =
   | 'paddingTop'
   | 'paddingBottom'
   | 'visible'
+  | 'cornerRadius'
   | 'topLeftRadius'
   | 'topRightRadius'
   | 'bottomLeftRadius'

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -1641,7 +1641,15 @@ interface DeprecatedBackgroundMixin {
   backgrounds: ReadonlyArray<Paint>
   backgroundStyleId: string
 }
-declare type StrokeCap = 'NONE' | 'ROUND' | 'SQUARE' | 'ARROW_LINES' | 'ARROW_EQUILATERAL'
+declare type StrokeCap =
+  | 'NONE'
+  | 'ROUND'
+  | 'SQUARE'
+  | 'ARROW_LINES'
+  | 'ARROW_EQUILATERAL'
+  | 'TRIANGLE_FILLED'
+  | 'DIAMOND_FILLED'
+  | 'CIRCLE_FILLED'
 declare type StrokeJoin = 'MITER' | 'BEVEL' | 'ROUND'
 declare type HandleMirroring = 'NONE' | 'ANGLE' | 'ANGLE_AND_LENGTH'
 interface AutoLayoutMixin {


### PR DESCRIPTION
1) Add cornerRadius to VariableBindableNodeField. [See Discord.](https://discord.com/channels/675194100147945497/899758994204266548/1252984217449791528)
2) Add missing values to StrokeCap. [See Discord.](https://discord.com/channels/675194100147945497/899758994204266548/1253246408455225405)