### PR TITLE
undo boundVariables nullability change

### DIFF
--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -983,7 +983,7 @@ interface DropShadowEffect {
   readonly visible: boolean
   readonly blendMode: BlendMode
   readonly showShadowBehindNode?: boolean
-  readonly boundVariables: {
+  readonly boundVariables?: {
     [field in VariableBindableEffectField]?: VariableAlias
   }
 }
@@ -995,7 +995,7 @@ interface InnerShadowEffect {
   readonly spread?: number
   readonly visible: boolean
   readonly blendMode: BlendMode
-  readonly boundVariables: {
+  readonly boundVariables?: {
     [field in VariableBindableEffectField]?: VariableAlias
   }
 }
@@ -1003,7 +1003,7 @@ interface BlurEffect {
   readonly type: 'LAYER_BLUR' | 'BACKGROUND_BLUR'
   readonly radius: number
   readonly visible: boolean
-  readonly boundVariables: {
+  readonly boundVariables?: {
     ['radius']?: VariableAlias
   }
 }
@@ -1035,7 +1035,7 @@ interface SolidPaint {
   readonly visible?: boolean
   readonly opacity?: number
   readonly blendMode?: BlendMode
-  readonly boundVariables: {
+  readonly boundVariables?: {
     [field in VariableBindablePaintField]?: VariableAlias
   }
 }
@@ -1085,7 +1085,7 @@ interface RowsColsLayoutGrid {
   readonly offset?: number
   readonly visible?: boolean
   readonly color?: RGBA
-  readonly boundVariables: {
+  readonly boundVariables?: {
     [field in VariableBindableLayoutGridField]?: VariableAlias
   }
 }
@@ -1094,7 +1094,7 @@ interface GridLayoutGrid {
   readonly sectionSize: number
   readonly visible?: boolean
   readonly color?: RGBA
-  readonly boundVariables: {
+  readonly boundVariables?: {
     ['sectionSize']?: VariableAlias
   }
 }
@@ -1235,7 +1235,7 @@ interface StyledTextSegment {
   openTypeFeatures: {
     readonly [feature in OpenTypeFeature]: boolean
   }
-  readonly boundVariables: {
+  boundVariables?: {
     [field in Exclude<
       VariableBindableTextField,
       'paragraphSpacing' | 'paragraphIndent'
@@ -1511,7 +1511,7 @@ interface SceneNodeMixin extends ExplicitVariableModesMixin {
         [nodeProperty in 'visible' | 'characters' | 'mainComponent']?: string
       }
     | null
-  readonly boundVariables: {
+  readonly boundVariables?: {
     readonly [field in VariableBindableNodeField]?: VariableAlias
   } & {
     readonly [field in VariableBindableTextField]?: VariableAlias[]
@@ -2158,7 +2158,7 @@ declare type ComponentProperties = {
     type: ComponentPropertyType
     value: string | boolean
     preferredValues?: InstanceSwapPreferredValue[]
-    readonly boundVariables: {
+    readonly boundVariables?: {
       [field in VariableBindableComponentPropertyField]?: VariableAlias
     }
   }
@@ -2519,7 +2519,7 @@ interface BaseStyleMixin extends PublishableMixin, PluginDataMixin {
 interface PaintStyle extends BaseStyleMixin {
   type: 'PAINT'
   paints: ReadonlyArray<Paint>
-  readonly boundVariables: {
+  readonly boundVariables?: {
     readonly [field in VariableBindablePaintStyleField]?: VariableAlias[]
   }
 }
@@ -2537,7 +2537,7 @@ interface TextStyle extends BaseStyleMixin {
   hangingPunctuation: boolean
   hangingList: boolean
   textCase: TextCase
-  readonly boundVariables: {
+  boundVariables?: {
     [field in VariableBindableTextField]?: VariableAlias
   }
   setBoundVariable(field: VariableBindableTextField, variable: Variable | null): void
@@ -2545,14 +2545,14 @@ interface TextStyle extends BaseStyleMixin {
 interface EffectStyle extends BaseStyleMixin {
   type: 'EFFECT'
   effects: ReadonlyArray<Effect>
-  readonly boundVariables: {
+  readonly boundVariables?: {
     readonly [field in VariableBindableEffectStyleField]?: VariableAlias[]
   }
 }
 interface GridStyle extends BaseStyleMixin {
   type: 'GRID'
   layoutGrids: ReadonlyArray<LayoutGrid>
-  readonly boundVariables: {
+  readonly boundVariables?: {
     readonly [field in VariableBindableGridStyleField]?: VariableAlias[]
   }
 }


### PR DESCRIPTION
This change undoes the removal of nullable modifiers from `boundVariables`, introduced in #303.


`boundVariables` is indeed non-nullable when _reading_ objects from the Plugin API, but several of the affected types, such as [Paint](/api/Paint/) and [Effect](/api/Effect/), are used for _writing_. In the write path, `boundVariables` is optional. Removing the nullable modifier caused typechecker errors in otherwise valid code. The nullable modifier has been added back in 1.99. Apologies to everyone who encountered difficulties, and apologies to anyone affected by the additional churn from this update!

We intend to release a typings update in the future that makes `boundVariables` non-nullable in specific situations, but the second attempt will more carefully address the write path.