### PR TITLE
🐛 Fix NodeChangeProperty not including the 'variant' key

### DIFF
--- a/plugin-api-standalone.d.ts
+++ b/plugin-api-standalone.d.ts
@@ -3648,6 +3648,7 @@ type NodeChangeProperty =
   | 'authorName'
   | 'code'
   | 'textBackground'
+  | 'variant'
 
 interface NodeChangeEvent {
   nodeChanges: NodeChange[]


### PR DESCRIPTION
## Add `'variant'` to `NodeChangeProperty`

### Problem

The `NodeChangeProperty` union type is missing `'variant'` as a valid value. However, at runtime, when a variant changes on an `InstanceNode`, the `documentchange` event does return `'variant'` inside the `properties` array:

```json
{
  "type": "PROPERTY_CHANGE",
  "properties": ["variant"]
}
```

This means plugin developers cannot check for variant changes in a type-safe way. The only workaround is an unsafe cast:

```ts
(change.properties as (NodeChangeProperty | 'variant')[]).includes('variant')
```

### Fix

Added `'variant'` to the `NodeChangeProperty` union type so that variant changes on `InstanceNode` can be detected without bypassing TypeScript's type system.

### Testing

You can verify the fix by listening to document changes and swapping the variant of an `InstanceNode` in the canvas:

```ts
figma.on('documentchange', (event) => {
  for (const change of event.documentChanges) {
    if (
      change.type === 'PROPERTY_CHANGE' &&
      change.properties.includes('variant') // ✅ now valid without casting
    ) {
      console.log('Variant changed on node:', change.node.id)
    }
  }
})
```