### PR TITLE
Update plugin typings

### DIFF
--- a/plugin-api-standalone.d.ts
+++ b/plugin-api-standalone.d.ts
@@ -445,6 +445,7 @@ interface PluginAPI {
    * This API is only available in Buzz.
    *
    * This property contains methods to work in Buzz.
+   *
    */
   readonly buzz: BuzzAPI
   /**
@@ -1451,6 +1452,7 @@ interface PluginAPI {
    * ### Change file extension
    *
    * For plugins our default template puts your code in a `code.ts` file. You should rename this to `code.tsx` so that you can use jsx in your plugin.
+   *
    */
   createNodeFromJSXAsync(jsx: any): Promise<SceneNode>
   /**
@@ -1548,6 +1550,7 @@ interface PluginAPI {
    *
    * Note: `getSelectionColors()` returns `null` if there is no selection, or
    * if there are too many colors in the selection (>1000).
+   *
    */
   getSelectionColors(): null | {
     paints: Paint[]
@@ -1698,6 +1701,7 @@ interface PluginAPI {
    * The `data` passed in must be encoded as a .MP4, .MOV, or .WebM. Videos have a maximum size of 100MB. Invalid videos will throw an error.
    *
    * Video can only be added to files in a paid Education, Professional, and Organization team. Plugins running on files in free Starter teams can edit existing video in a file but not upload video to it.
+   *
    */
   createVideoAsync(data: Uint8Array): Promise<Video>
   /**
@@ -1723,6 +1727,7 @@ interface PluginAPI {
    * ```
    *
    * @param url
+   *
    */
   createLinkPreviewAsync(url: string): Promise<EmbedNode | LinkUnfurlNode>
   /**
@@ -1735,6 +1740,7 @@ interface PluginAPI {
    * This API is only available in FigJam
    *
    * @param hash
+   *
    */
   createGif(hash: string): MediaNode
   /**
@@ -1875,6 +1881,7 @@ interface PluginAPI {
   base64Decode(data: string): Uint8Array
   /**
    * Gets the node that is currently being used for file thumbnail, or null if the default thumbnail is used.
+   *
    */
   getFileThumbnailNodeAsync(): Promise<
     FrameNode | ComponentNode | ComponentSetNode | SectionNode | null
@@ -1883,10 +1890,12 @@ interface PluginAPI {
    * @deprecated Use {@link PluginAPI.getFileThumbnailNodeAsync} instead. This function will throw an exception if the plugin manifest contains `"documentAccess": "dynamic-page"`.
    *
    * Gets the node that is currently being used for file thumbnail, or null if the default thumbnail is used.
+   *
    */
   getFileThumbnailNode(): FrameNode | ComponentNode | ComponentSetNode | SectionNode | null
   /**
    * Set `node` to be the thumbnail for the file. If `node` is null, then use the default thumbnail.
+   *
    */
   setFileThumbnailNodeAsync(
     node: FrameNode | ComponentNode | ComponentSetNode | SectionNode | null,
@@ -2024,6 +2033,7 @@ interface PluginAPI {
    * @remarks
    *
    * Calling this function without rowIndex and columnIndex will move the node to the end of the grid
+   *
    */
   moveNodesToCoord(nodeIds: string[], rowIndex?: number, columnIndex?: number): void
   /**
@@ -2587,8 +2597,11 @@ interface ClientStorageAPI {
  */
 interface NotificationOptions {
   timeout?: number
+
   error?: boolean
+
   onDequeue?: (reason: NotifyDequeueReason) => void
+
   button?: {
     text: string
     action: () => boolean | void
@@ -2609,13 +2622,18 @@ interface NotificationHandler {
  */
 interface ShowUIOptions {
   visible?: boolean
+
   title?: string
+
   width?: number
+
   height?: number
+
   position?: {
     x: number
     y: number
   }
+
   themeColors?: boolean
 }
 /**
@@ -2852,6 +2870,7 @@ interface ConstantsAPI {
    * ```
    *
    * @remarks
+   *
    */
   colors: ColorPalettes
 }
@@ -2984,12 +3003,14 @@ interface CodegenAPI {
    *   readonly customSettings: Record<string, string>
    * }
    * ```
+   *
    */
   readonly preferences: CodegenPreferences
   /**
    * Triggers the `figma.codegen.on("generate")` callback again.
    *
    * This is is useful for plugins that need to refresh the codegen output. For example, if you’re using an iframe to provide more customization options.
+   *
    */
   refresh: () => void
 }
@@ -3064,7 +3085,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   on(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   on(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
   /**
    * Create a handler for when the linkpreview, auth, and open events are first triggered. This only gets called once.
@@ -3073,7 +3096,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   once(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   once(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
   /**
    * Remove a handler for the linkpreview, auth, and open events.
@@ -3082,7 +3107,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   off(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   off(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
 }
 /**
@@ -3133,14 +3160,17 @@ interface ViewportAPI {
    * - zoom &lt; 1: design is zoomed out
    * - zoom = 1: design is shown at exact size
    * - zoom &gt; 1: design is zoomed in
+   *
    */
   zoom: number
   /**
    * Automatically sets the viewport coordinates such that the nodes are visible on screen. It is the equivalent of pressing Shift-1.
+   *
    */
   scrollAndZoomIntoView(nodes: ReadonlyArray<BaseNode>): void
   /**
    * The bounds of the viewport of the page that is currently visible on screen. The (x, y) corresponds to the top-left of the screen. User actions such as resizing the window or showing/hiding the rulers/UI will change the bounds of the viewport.
+   *
    */
   readonly bounds: Rect
   /**
@@ -3168,6 +3198,7 @@ interface ViewportAPI {
    * We have updated all of the create methods (`figma.createRectangle()`, `figma.createLine()`, etc) so that when the Figma Slides file is in Single Slide View,
    * they append that node to the focused slide instead of to the canvas. This is to ensure that the node you are creating is viewable by the current user and
    * not hidden off to the side of the larger grid view.
+   *
    */
   slidesView: 'grid' | 'single-slide'
   /**
@@ -3195,6 +3226,7 @@ interface ViewportAPI {
    * We have updated all of the create methods (`figma.createRectangle()`, `figma.createLine()`, etc) so that when the Figma Slides/Buzz file is in Asset View,
    * they append that node to the focused asset/slide instead of to the canvas. This is to ensure that the node you are creating is viewable by the current user and
    * not hidden off to the side of the larger grid view.
+   *
    */
   canvasView: 'grid' | 'single-asset'
 }
@@ -3330,14 +3362,17 @@ declare type ParameterInputEvent<ParametersType = ParameterValues> = {
 interface ParametersAPI {
   /**
    * Register a handler for user input events in the quick action UI.
+   *
    */
   on(type: 'input', callback: (event: ParameterInputEvent) => void): void
   /**
    * Register a handler for user input events in the quick action UI. Same as `figma.parameters.on("input")`, but only gets called the first time.
+   *
    */
   once(type: 'input', callback: (event: ParameterInputEvent) => void): void
   /**
    * Removes a handler added via `figma.parameters.on`.
+   *
    */
   off(type: 'input', callback: (event: ParameterInputEvent) => void): void
 }
@@ -3346,12 +3381,15 @@ interface ParametersAPI {
  */
 interface RunParametersEvent<ParametersType = ParameterValues | undefined> {
   command: string
+
   parameters: ParametersType
 }
 
 interface OpenDevResourcesEvent {
   command: 'open-dev-resource'
+
   parameters?: undefined
+
   link: {
     url: string
     name: string
@@ -3368,6 +3406,7 @@ interface SlidesViewChangeEvent {
  *
  * This event is triggered when users switch between Asset View and Grid View
  * in the Slides or Buzz interface, allowing plugins to respond to view changes.
+ *
  */
 interface CanvasViewChangeEvent {
   /**
@@ -3380,24 +3419,35 @@ interface CanvasViewChangeEvent {
 
 interface DropEvent {
   node: BaseNode | SceneNode
+
   x: number
+
   y: number
+
   absoluteX: number
+
   absoluteY: number
+
   items: DropItem[]
+
   files: DropFile[]
+
   dropMetadata?: any
 }
 
 interface DropItem {
   type: string
+
   data: string
 }
 
 interface DropFile {
   name: string
+
   type: string
+
   getBytesAsync(): Promise<Uint8Array>
+
   getTextAsync(): Promise<string>
 }
 
@@ -3514,6 +3564,7 @@ interface StyleDeleteChange extends BaseStyleChange {
    * The string literal "STYLE_DELETE" representing the type of document change this is. Always check the type before reading other properties. In this case, the returned style is null.
    */
   type: 'STYLE_DELETE'
+
   style: null
 }
 /**
@@ -5496,6 +5547,7 @@ interface BaseNodeMixin extends PluginDataMixin, DevResourcesMixin {
   readonly isAsset: boolean
   /**
    * Resolves to a JSON object of CSS properties of the node. This is the same CSS that Figma shows in the inspect panel and is helpful if you are building a [plugin for code generation](https://developers.figma.com/docs/plugins/codegen-plugins).
+   *
    */
   getCSSAsync(): Promise<{
     [key: string]: string
@@ -5581,6 +5633,7 @@ interface DevResourcesMixin {
    *
    * @param url - The url of the dev resource.
    * @param name - The name of the dev resource. If not provided, Figma will get the name from the url.
+   *
    */
   addDevResourceAsync(url: string, name?: string): Promise<void>
   /**
@@ -5589,6 +5642,7 @@ interface DevResourcesMixin {
    *
    * @param currentUrl - The current url of the dev resource.
    * @param newValue - The new name and/or url of the dev resource.
+   *
    */
   editDevResourceAsync(
     currentUrl: string,
@@ -7674,7 +7728,7 @@ interface ScatterBrushProperties {
   gap: number
   /** The amount of random movement applied to brush instances along the stroke path. The minimum value is 0. */
   wiggle: number
-  /** The amount of random size variation applied to brush instances. Ranges from 0 to 3.*/
+  /** The amount of random size variation applied to brush instances. Ranges from 0 to 3. */
   sizeJitter: number
   /** The amount of random angular variation in degrees applied to brush instances. Ranges from -180 to 180. */
   angularJitter: number
@@ -7721,11 +7775,11 @@ type BrushStrokeProperties = StretchBrushProperties | ScatterBrushProperties
 interface DynamicStrokeProperties {
   /** The type of complex stroke. Fixed to 'DYNAMIC'. */
   type: 'DYNAMIC'
-  /** The frequency of the dynamic stroke. Ranges from 0.01 to 20.*/
+  /** The frequency of the dynamic stroke. Ranges from 0.01 to 20. */
   frequency: number
-  /** The amplitude of the wiggles in the dynamic stroke. Minimum value is 0.*/
+  /** The amplitude of the wiggles in the dynamic stroke. Minimum value is 0. */
   wiggle: number
-  /** The amount of smoothing applied to the dynamic stroke. Ranges from 0 to 1.*/
+  /** The amount of smoothing applied to the dynamic stroke. Ranges from 0 to 1. */
   smoothen: number
 }
 /**
@@ -7808,15 +7862,19 @@ interface CornerMixin {
  */
 interface RectangleCornerMixin {
   /**
+   * The radius of the top left corner, in pixels. This value must be non-negative and can be fractional.
    */
   topLeftRadius: number
   /**
+   * The radius of the top right corner, in pixels. This value must be non-negative and can be fractional.
    */
   topRightRadius: number
   /**
+   * The radius of the bottom left corner, in pixels. This value must be non-negative and can be fractional.
    */
   bottomLeftRadius: number
   /**
+   * The radius of the bottom right corner, in pixels. This value must be non-negative and can be fractional.
    */
   bottomRightRadius: number
 }
@@ -7891,7 +7949,9 @@ interface ExportMixin {
    * ```
    */
   exportAsync(settings?: ExportSettings): Promise<Uint8Array>
+
   exportAsync(settings: ExportSettingsSVGString): Promise<string>
+
   exportAsync(settings: ExportSettingsREST): Promise<Object>
 }
 /**
@@ -8168,6 +8228,7 @@ interface PublishableMixin {
   readonly key: string
   /**
    * Gets the status of this style/component in the team library.
+   *
    */
   getPublishStatusAsync(): Promise<PublishStatus>
 }
@@ -8648,6 +8709,7 @@ interface ComponentPropertiesMixin {
    * - `defaultValue` is supported for `'BOOLEAN'`, `'TEXT'`, and `'INSTANCE_SWAP'` properties, but not for `'VARIANT'` or `'SLOT'` properties
    * - `preferredValues` is only supported for `'INSTANCE_SWAP'` and `'SLOT'` properties
    * - `description` is only supported for `'SLOT'` properties
+   * - `slotSettings` is only supported for `'SLOT'` properties
    */
   editComponentProperty(
     propertyName: string,
@@ -8656,6 +8718,7 @@ interface ComponentPropertiesMixin {
       defaultValue?: string | boolean | VariableAlias
       preferredValues?: InstanceSwapPreferredValue[]
       description?: string
+      slotSettings?: SlotSettings
     },
   ): string
   /**
@@ -9500,10 +9563,12 @@ interface PageNode
    * | [`CreateChange`](https://developers.figma.com/docs/plugins/api/NodeChange#createchange) | `'CREATE'` | A node has been created in the page. If a node with nested children is being added to the page a `CreateChange` will only be made for the highest level parent that was added to the page. |
    * | [`DeleteChange`](https://developers.figma.com/docs/plugins/api/NodeChange#deletechange) | `'DELETE'` | A node has been removed from the page. If a node with nested children is being removed from the page a  `DeleteChange`  will only be made for the highest level parent that was removed from the page. |
    * | [`PropertyChange`](https://developers.figma.com/docs/plugins/api/NodeChange#propertychange) | `'PROPERTY_CHANGE'` | A property of a node has changed. |
+   *
    */
   on(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
    * Same as {@link PageNode.on}, but the callback will only be called once, the first time the specified event happens.
+   *
    */
   once(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
@@ -9525,6 +9590,7 @@ interface PageNode
    * page.on("nodechange", () => { console.log("nodechange") })
    * page.off("nodechange", () => { console.log("nodechange") })
    * ```
+   *
    */
   off(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
@@ -9884,12 +9950,20 @@ type InstanceSwapPreferredValue = {
   type: 'COMPONENT' | 'COMPONENT_SET'
   key: string
 }
+type SlotSettings = {
+  stretchChildOnInsert?: boolean
+  displayEmptyByDefault?: boolean
+  minChildren?: number | null
+  maxChildren?: number | null
+  allowPreferredValuesOnly?: boolean
+}
 /**
  * @see https://developers.figma.com/docs/plugins/api/ComponentPropertyOptions
  */
 type ComponentPropertyOptions = {
   preferredValues?: InstanceSwapPreferredValue[]
   description?: string
+  slotSettings?: SlotSettings
 }
 /**
  * @see https://developers.figma.com/docs/plugins/api/ComponentPropertyDefinitions
@@ -9901,8 +9975,9 @@ type ComponentPropertyDefinitions = {
     preferredValues?: InstanceSwapPreferredValue[]
     variantOptions?: string[]
     description?: string
+    slotSettings?: SlotSettings
     readonly boundVariables?: {
-      [field in VariableBindableComponentPropertyField]?: VariableAlias
+      [field in VariableBindableComponentPropertyDefinitionField]?: VariableAlias
     }
   }
 }
@@ -10064,6 +10139,14 @@ interface SlotNode extends DefaultFrameMixin {
    * Resets a given slot node to the original component slot content.
    */
   resetSlot(): void
+  /**
+   * The set of limits, configured on the corresponding `'SLOT'` component property's {@link SlotSettings}, that the current contents of this slot violate. Returns an empty array when within limits. Multiple kinds may be present simultaneously (e.g. `['BELOW_MIN', 'HAS_NON_PREFERRED']`), since `HAS_NON_PREFERRED` is independent of the child count. `BELOW_MIN` and `ABOVE_MAX` are mutually exclusive.
+   *
+   * - `'BELOW_MIN'`: the slot has fewer children than its configured `minChildren`.
+   * - `'ABOVE_MAX'`: the slot has more children than its configured `maxChildren`.
+   * - `'HAS_NON_PREFERRED'`: the slot contains a child that is not in the property's preferred values, while `allowPreferredValuesOnly` is `true`.
+   */
+  readonly limitViolations: Array<'BELOW_MIN' | 'ABOVE_MAX' | 'HAS_NON_PREFERRED'>
 }
 interface BooleanOperationNode
   extends DefaultShapeMixin,
@@ -10129,6 +10212,7 @@ interface StampNode
    * if the stamp was created before July 2022 or if the user is currently not connected to the internet.
    *
    * `fileusers` must be specified in the permissions array in `manifest.json` to access this function.
+   *
    */
   getAuthorAsync(): Promise<BaseUser | null>
 }
@@ -10241,9 +10325,13 @@ interface TableCellNode extends MinimalFillsMixin {
    * The column index of this cell relative to its parent table.
    */
   readonly columnIndex: number
+
   readonly toString: string
+
   readonly parent: TableNode
+
   readonly height: number
+
   readonly width: number
 }
 interface HighlightNode
@@ -10871,6 +10959,7 @@ interface WidgetNode extends OpaqueNodeMixin, StickableMixin {
    * Caution: NOTE: every key in `syncedMapOverrides` will override the entire corresponding synced map, deleting all existing keys in the map. If you wish to preserve some of the keys in the map, you'll need to explicitly specify them in the override.
    *
    * For more information, check out [this page in our widget documentation](https://figma.com/widget-docs/managing-multiple-widgets#widgetnodeclonewidget).
+   *
    */
   cloneWidget(
     syncedStateOverrides: {
@@ -10894,6 +10983,7 @@ interface WidgetNode extends OpaqueNodeMixin, StickableMixin {
    * If you try to set the synced state for a widget with a different version of the same widget, that widget will automatically update to match the running widget's version. This ensures that the synced state values you set will always be compatible with the widget. A side effect of this is that a widget may get downgraded to a lower version.
    *
    * To get a list of other widgets with the same `widgetId`, check out [findWidgetNodesByWidgetId](https://developers.figma.com/docs/plugins/api/properties/nodes-findwidgetnodesbywidgetid).
+   *
    */
   setWidgetSyncedState(
     syncedState: {
@@ -11269,6 +11359,7 @@ interface BaseStyleMixin extends PublishableMixin, PluginDataMixin {
    * The unique identifier of the style in the document the plugin is executing from. You can assign this value via `setFillStyleIdAsync`, `setStrokeStyleIdAsync`, `setTextStyleIdAsync`, etc. to make the node properties reflect that of the style node.
    */
   readonly id: string
+
   readonly type: StyleType
   /**
    * The consumers of this style. The `fields` in `StyleConsumers` refers to the field where the style is applied (e.g. a PaintStyle can be applied in `setFillStyleIdAsync` or `setStrokeStyleIdAsync`).
@@ -11545,12 +11636,12 @@ interface FindAllCriteria<T extends NodeType[]> {
 /**
  * @see https://developers.figma.com/docs/plugins/api/TransformModifier
  */
-interface TransformModifier {}
+type TransformModifier = LinearRepeatModifier | RadialRepeatModifier
 /**
  * @see https://developers.figma.com/docs/plugins/api/TransformModifier
  * Base interface for repeat transform modifiers.
  */
-interface RepeatModifier extends TransformModifier {
+interface RepeatModifier {
   /** Type of transform modifier. Currently, only 'REPEAT' is supported. */
   type: 'REPEAT'
   /** Number of times to repeat the children. */
@@ -11580,4 +11671,4 @@ interface RadialRepeatModifier extends RepeatModifier {
 }
 
 // prettier-ignore
-export { ArgFreeEventType, PluginAPI, VersionHistoryResult, VariablesAPI, LibraryVariableCollection, LibraryVariable, AnnotationsAPI, BuzzAPI, BuzzTextField, BuzzMediaField, BuzzAssetType, TeamLibraryAPI, PaymentStatus, PaymentsAPI, ClientStorageAPI, NotificationOptions, NotifyDequeueReason, NotificationHandler, ShowUIOptions, UIPostMessageOptions, OnMessageProperties, MessageEventHandler, UIAPI, UtilAPI, ColorPalette, ColorPalettes, ConstantsAPI, CodegenEvent, CodegenPreferences, CodegenPreferencesEvent, CodegenResult, CodegenAPI, DevResource, DevResourceWithNodeId, LinkPreviewEvent, PlainTextElement, LinkPreviewResult, AuthEvent, DevResourceOpenEvent, AuthResult, VSCodeAPI, DevResourcesAPI, TimerAPI, ViewportAPI, TextReviewAPI, ParameterValues, SuggestionResults, ParameterInputEvent, ParametersAPI, RunParametersEvent, OpenDevResourcesEvent, RunEvent, SlidesViewChangeEvent, CanvasViewChangeEvent, DropEvent, DropItem, DropFile, DocumentChangeEvent, StyleChangeEvent, StyleChange, BaseDocumentChange, BaseNodeChange, RemovedNode, CreateChange, DeleteChange, PropertyChange, BaseStyleChange, StyleCreateChange, StyleDeleteChange, StylePropertyChange, DocumentChange, NodeChangeProperty, NodeChangeEvent, NodeChange, StyleChangeProperty, TextReviewEvent, TextReviewRange, Transform, Vector, Rect, RGB, RGBA, FontName, TextCase, TextDecoration, TextDecorationStyle, FontStyle, TextDecorationOffset, TextDecorationThickness, TextDecorationColor, OpenTypeFeature, ArcData, DropShadowEffect, InnerShadowEffect, BlurEffectBase, BlurEffectNormal, BlurEffectProgressive, BlurEffect, NoiseEffectBase, NoiseEffectMonotone, NoiseEffectDuotone, NoiseEffectMultitone, NoiseEffect, TextureEffect, GlassEffect, Effect, ConstraintType, Constraints, ColorStop, ImageFilters, SolidPaint, GradientPaint, ImagePaint, VideoPaint, PatternPaint, Paint, Guide, RowsColsLayoutGrid, GridLayoutGrid, LayoutGrid, ExportSettingsConstraints, ExportSettingsImage, ExportSettingsSVGBase, ExportSettingsSVG, ExportSettingsSVGString, ExportSettingsPDF, ExportSettingsREST, ExportSettings, WindingRule, VectorVertex, VectorSegment, VectorRegion, VectorNetwork, VectorPath, VectorPaths, LetterSpacing, LineHeight, LeadingTrim, HyperlinkTarget, TextListOptions, BlendMode, MaskType, Font, TextStyleOverrideType, StyledTextSegment, TextPathStartData, Reaction, VariableDataType, ExpressionFunction, Expression, VariableValueWithExpression, VariableData, ConditionalBlock, DevStatus, Action, SimpleTransition, DirectionalTransition, Transition, Trigger, Navigation, Easing, EasingFunctionBezier, EasingFunctionSpring, OverflowDirection, OverlayPositionType, OverlayBackground, OverlayBackgroundInteraction, PublishStatus, ConnectorEndpointPosition, ConnectorEndpointPositionAndEndpointNodeId, ConnectorEndpointEndpointNodeIdAndMagnet, ConnectorEndpoint, ConnectorStrokeCap, BaseNodeMixin, PluginDataMixin, DevResourcesMixin, DevStatusMixin, SceneNodeMixin, VariableBindableNodeField, VariableBindableTextField, VariableBindablePaintField, VariableBindablePaintStyleField, VariableBindableColorStopField, VariableBindableEffectField, VariableBindableEffectStyleField, VariableBindableLayoutGridField, VariableBindableGridStyleField, VariableBindableComponentPropertyField, VariableBindableComponentPropertyDefinitionField, StickableMixin, ChildrenMixin, ConstraintMixin, DimensionAndPositionMixin, LayoutMixin, AspectRatioLockMixin, BlendMixin, ContainerMixin, DeprecatedBackgroundMixin, StrokeCap, StrokeJoin, HandleMirroring, AutoLayoutMixin, GridTrackSize, GridTrackReorderOptions, GridTrackReorderEntry, GridLayoutMixin, AutoLayoutChildrenMixin, GridChildrenMixin, InferredAutoLayoutResult, DetachedInfo, MinimalStrokesMixin, IndividualStrokesMixin, MinimalFillsMixin, VariableWidthPoint, PresetVariableWidthStrokeProperties, CustomVariableWidthStrokeProperties, VariableWidthStrokeProperties, ComplexStrokeProperties, ScatterBrushProperties, StretchBrushProperties, BrushStrokeProperties, DynamicStrokeProperties, GeometryMixin, ComplexStrokesMixin, CornerMixin, RectangleCornerMixin, ExportMixin, FramePrototypingMixin, VectorLikeMixin, ReactionMixin, DocumentationLink, PublishableMixin, DefaultShapeMixin, BaseFrameMixin, DefaultFrameMixin, OpaqueNodeMixin, MinimalBlendMixin, Annotation, AnnotationProperty, AnnotationPropertyType, AnnotationsMixin, Measurement, MeasurementSide, MeasurementOffset, MeasurementsMixin, VariantMixin, ComponentPropertiesMixin, BaseNonResizableTextMixin, NonResizableTextMixin, NonResizableTextPathMixin, TextSublayerNode, DocumentNode, ExplicitVariableModesMixin, PageNode, FrameNode, GroupNode, TransformGroupNode, SliceNode, RectangleNode, LineNode, EllipseNode, PolygonNode, StarNode, VectorNode, TextNode, TextPathNode, ComponentPropertyType, InstanceSwapPreferredValue, ComponentPropertyOptions, ComponentPropertyDefinitions, ComponentSetNode, ComponentNode, ComponentProperties, InstanceNode, SlotNode, BooleanOperationNode, StickyNode, StampNode, TableNode, TableCellNode, HighlightNode, WashiTapeNode, ShapeWithTextNode, CodeBlockNode, LabelSublayerNode, ConnectorNode, VariableResolvedDataType, VariableAlias, VariableValue, VariableScope, CodeSyntaxPlatform, Variable, VariableCollection, ExtendedVariableCollection, AnnotationCategoryColor, AnnotationCategory, WidgetNode, EmbedData, EmbedNode, LinkUnfurlData, LinkUnfurlNode, MediaData, MediaNode, SectionNode, SlideNode, SlideRowNode, SlideGridNode, InteractiveSlideElementNode, SlideTransition, BaseNode, SceneNode, NodeType, StyleType, InheritedStyleField, StyleConsumers, BaseStyleMixin, PaintStyle, TextStyle, EffectStyle, GridStyle, BaseStyle, Image, Video, BaseUser, User, ActiveUser, FindAllCriteria, TransformModifier, RepeatModifier, LinearRepeatModifier, RadialRepeatModifier }
+export { ArgFreeEventType, PluginAPI, VersionHistoryResult, VariablesAPI, LibraryVariableCollection, LibraryVariable, AnnotationsAPI, BuzzAPI, BuzzTextField, BuzzMediaField, BuzzAssetType, TeamLibraryAPI, PaymentStatus, PaymentsAPI, ClientStorageAPI, NotificationOptions, NotifyDequeueReason, NotificationHandler, ShowUIOptions, UIPostMessageOptions, OnMessageProperties, MessageEventHandler, UIAPI, UtilAPI, ColorPalette, ColorPalettes, ConstantsAPI, CodegenEvent, CodegenPreferences, CodegenPreferencesEvent, CodegenResult, CodegenAPI, DevResource, DevResourceWithNodeId, LinkPreviewEvent, PlainTextElement, LinkPreviewResult, AuthEvent, DevResourceOpenEvent, AuthResult, VSCodeAPI, DevResourcesAPI, TimerAPI, ViewportAPI, TextReviewAPI, ParameterValues, SuggestionResults, ParameterInputEvent, ParametersAPI, RunParametersEvent, OpenDevResourcesEvent, RunEvent, SlidesViewChangeEvent, CanvasViewChangeEvent, DropEvent, DropItem, DropFile, DocumentChangeEvent, StyleChangeEvent, StyleChange, BaseDocumentChange, BaseNodeChange, RemovedNode, CreateChange, DeleteChange, PropertyChange, BaseStyleChange, StyleCreateChange, StyleDeleteChange, StylePropertyChange, DocumentChange, NodeChangeProperty, NodeChangeEvent, NodeChange, StyleChangeProperty, TextReviewEvent, TextReviewRange, Transform, Vector, Rect, RGB, RGBA, FontName, TextCase, TextDecoration, TextDecorationStyle, FontStyle, TextDecorationOffset, TextDecorationThickness, TextDecorationColor, OpenTypeFeature, ArcData, DropShadowEffect, InnerShadowEffect, BlurEffectBase, BlurEffectNormal, BlurEffectProgressive, BlurEffect, NoiseEffectBase, NoiseEffectMonotone, NoiseEffectDuotone, NoiseEffectMultitone, NoiseEffect, TextureEffect, GlassEffect, Effect, ConstraintType, Constraints, ColorStop, ImageFilters, SolidPaint, GradientPaint, ImagePaint, VideoPaint, PatternPaint, Paint, Guide, RowsColsLayoutGrid, GridLayoutGrid, LayoutGrid, ExportSettingsConstraints, ExportSettingsImage, ExportSettingsSVGBase, ExportSettingsSVG, ExportSettingsSVGString, ExportSettingsPDF, ExportSettingsREST, ExportSettings, WindingRule, VectorVertex, VectorSegment, VectorRegion, VectorNetwork, VectorPath, VectorPaths, LetterSpacing, LineHeight, LeadingTrim, HyperlinkTarget, TextListOptions, BlendMode, MaskType, Font, TextStyleOverrideType, StyledTextSegment, TextPathStartData, Reaction, VariableDataType, ExpressionFunction, Expression, VariableValueWithExpression, VariableData, ConditionalBlock, DevStatus, Action, SimpleTransition, DirectionalTransition, Transition, Trigger, Navigation, Easing, EasingFunctionBezier, EasingFunctionSpring, OverflowDirection, OverlayPositionType, OverlayBackground, OverlayBackgroundInteraction, PublishStatus, ConnectorEndpointPosition, ConnectorEndpointPositionAndEndpointNodeId, ConnectorEndpointEndpointNodeIdAndMagnet, ConnectorEndpoint, ConnectorStrokeCap, BaseNodeMixin, PluginDataMixin, DevResourcesMixin, DevStatusMixin, SceneNodeMixin, VariableBindableNodeField, VariableBindableTextField, VariableBindablePaintField, VariableBindablePaintStyleField, VariableBindableColorStopField, VariableBindableEffectField, VariableBindableEffectStyleField, VariableBindableLayoutGridField, VariableBindableGridStyleField, VariableBindableComponentPropertyField, VariableBindableComponentPropertyDefinitionField, StickableMixin, ChildrenMixin, ConstraintMixin, DimensionAndPositionMixin, LayoutMixin, AspectRatioLockMixin, BlendMixin, ContainerMixin, DeprecatedBackgroundMixin, StrokeCap, StrokeJoin, HandleMirroring, AutoLayoutMixin, GridTrackSize, GridTrackReorderOptions, GridTrackReorderEntry, GridLayoutMixin, AutoLayoutChildrenMixin, GridChildrenMixin, InferredAutoLayoutResult, DetachedInfo, MinimalStrokesMixin, IndividualStrokesMixin, MinimalFillsMixin, VariableWidthPoint, PresetVariableWidthStrokeProperties, CustomVariableWidthStrokeProperties, VariableWidthStrokeProperties, ComplexStrokeProperties, ScatterBrushProperties, StretchBrushProperties, BrushStrokeProperties, DynamicStrokeProperties, GeometryMixin, ComplexStrokesMixin, CornerMixin, RectangleCornerMixin, ExportMixin, FramePrototypingMixin, VectorLikeMixin, ReactionMixin, DocumentationLink, PublishableMixin, DefaultShapeMixin, BaseFrameMixin, DefaultFrameMixin, OpaqueNodeMixin, MinimalBlendMixin, Annotation, AnnotationProperty, AnnotationPropertyType, AnnotationsMixin, Measurement, MeasurementSide, MeasurementOffset, MeasurementsMixin, VariantMixin, ComponentPropertiesMixin, BaseNonResizableTextMixin, NonResizableTextMixin, NonResizableTextPathMixin, TextSublayerNode, DocumentNode, ExplicitVariableModesMixin, PageNode, FrameNode, GroupNode, TransformGroupNode, SliceNode, RectangleNode, LineNode, EllipseNode, PolygonNode, StarNode, VectorNode, TextNode, TextPathNode, ComponentPropertyType, InstanceSwapPreferredValue, SlotSettings, ComponentPropertyOptions, ComponentPropertyDefinitions, ComponentSetNode, ComponentNode, ComponentProperties, InstanceNode, SlotNode, BooleanOperationNode, StickyNode, StampNode, TableNode, TableCellNode, HighlightNode, WashiTapeNode, ShapeWithTextNode, CodeBlockNode, LabelSublayerNode, ConnectorNode, VariableResolvedDataType, VariableAlias, VariableValue, VariableScope, CodeSyntaxPlatform, Variable, VariableCollection, ExtendedVariableCollection, AnnotationCategoryColor, AnnotationCategory, WidgetNode, EmbedData, EmbedNode, LinkUnfurlData, LinkUnfurlNode, MediaData, MediaNode, SectionNode, SlideNode, SlideRowNode, SlideGridNode, InteractiveSlideElementNode, SlideTransition, BaseNode, SceneNode, NodeType, StyleType, InheritedStyleField, StyleConsumers, BaseStyleMixin, PaintStyle, TextStyle, EffectStyle, GridStyle, BaseStyle, Image, Video, BaseUser, User, ActiveUser, FindAllCriteria, TransformModifier, RepeatModifier, LinearRepeatModifier, RadialRepeatModifier }

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -445,6 +445,7 @@ interface PluginAPI {
    * This API is only available in Buzz.
    *
    * This property contains methods to work in Buzz.
+   *
    */
   readonly buzz: BuzzAPI
   /**
@@ -1451,6 +1452,7 @@ interface PluginAPI {
    * ### Change file extension
    *
    * For plugins our default template puts your code in a `code.ts` file. You should rename this to `code.tsx` so that you can use jsx in your plugin.
+   *
    */
   createNodeFromJSXAsync(jsx: any): Promise<SceneNode>
   /**
@@ -1548,6 +1550,7 @@ interface PluginAPI {
    *
    * Note: `getSelectionColors()` returns `null` if there is no selection, or
    * if there are too many colors in the selection (>1000).
+   *
    */
   getSelectionColors(): null | {
     paints: Paint[]
@@ -1698,6 +1701,7 @@ interface PluginAPI {
    * The `data` passed in must be encoded as a .MP4, .MOV, or .WebM. Videos have a maximum size of 100MB. Invalid videos will throw an error.
    *
    * Video can only be added to files in a paid Education, Professional, and Organization team. Plugins running on files in free Starter teams can edit existing video in a file but not upload video to it.
+   *
    */
   createVideoAsync(data: Uint8Array): Promise<Video>
   /**
@@ -1723,6 +1727,7 @@ interface PluginAPI {
    * ```
    *
    * @param url
+   *
    */
   createLinkPreviewAsync(url: string): Promise<EmbedNode | LinkUnfurlNode>
   /**
@@ -1735,6 +1740,7 @@ interface PluginAPI {
    * This API is only available in FigJam
    *
    * @param hash
+   *
    */
   createGif(hash: string): MediaNode
   /**
@@ -1875,6 +1881,7 @@ interface PluginAPI {
   base64Decode(data: string): Uint8Array
   /**
    * Gets the node that is currently being used for file thumbnail, or null if the default thumbnail is used.
+   *
    */
   getFileThumbnailNodeAsync(): Promise<
     FrameNode | ComponentNode | ComponentSetNode | SectionNode | null
@@ -1883,10 +1890,12 @@ interface PluginAPI {
    * @deprecated Use {@link PluginAPI.getFileThumbnailNodeAsync} instead. This function will throw an exception if the plugin manifest contains `"documentAccess": "dynamic-page"`.
    *
    * Gets the node that is currently being used for file thumbnail, or null if the default thumbnail is used.
+   *
    */
   getFileThumbnailNode(): FrameNode | ComponentNode | ComponentSetNode | SectionNode | null
   /**
    * Set `node` to be the thumbnail for the file. If `node` is null, then use the default thumbnail.
+   *
    */
   setFileThumbnailNodeAsync(
     node: FrameNode | ComponentNode | ComponentSetNode | SectionNode | null,
@@ -2024,6 +2033,7 @@ interface PluginAPI {
    * @remarks
    *
    * Calling this function without rowIndex and columnIndex will move the node to the end of the grid
+   *
    */
   moveNodesToCoord(nodeIds: string[], rowIndex?: number, columnIndex?: number): void
   /**
@@ -2587,8 +2597,11 @@ interface ClientStorageAPI {
  */
 interface NotificationOptions {
   timeout?: number
+
   error?: boolean
+
   onDequeue?: (reason: NotifyDequeueReason) => void
+
   button?: {
     text: string
     action: () => boolean | void
@@ -2609,13 +2622,18 @@ interface NotificationHandler {
  */
 interface ShowUIOptions {
   visible?: boolean
+
   title?: string
+
   width?: number
+
   height?: number
+
   position?: {
     x: number
     y: number
   }
+
   themeColors?: boolean
 }
 /**
@@ -2852,6 +2870,7 @@ interface ConstantsAPI {
    * ```
    *
    * @remarks
+   *
    */
   colors: ColorPalettes
 }
@@ -2984,12 +3003,14 @@ interface CodegenAPI {
    *   readonly customSettings: Record<string, string>
    * }
    * ```
+   *
    */
   readonly preferences: CodegenPreferences
   /**
    * Triggers the `figma.codegen.on("generate")` callback again.
    *
    * This is is useful for plugins that need to refresh the codegen output. For example, if you’re using an iframe to provide more customization options.
+   *
    */
   refresh: () => void
 }
@@ -3064,7 +3085,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   on(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   on(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
   /**
    * Create a handler for when the linkpreview, auth, and open events are first triggered. This only gets called once.
@@ -3073,7 +3096,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   once(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   once(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
   /**
    * Remove a handler for the linkpreview, auth, and open events.
@@ -3082,7 +3107,9 @@ interface DevResourcesAPI {
     type: 'linkpreview',
     callback: (event: LinkPreviewEvent) => Promise<LinkPreviewResult> | LinkPreviewResult,
   ): void
+
   off(type: 'auth', callback: (event: AuthEvent) => Promise<AuthResult> | AuthResult): void
+
   off(type: 'open', callback: (event: DevResourceOpenEvent) => void): void
 }
 /**
@@ -3133,14 +3160,17 @@ interface ViewportAPI {
    * - zoom &lt; 1: design is zoomed out
    * - zoom = 1: design is shown at exact size
    * - zoom &gt; 1: design is zoomed in
+   *
    */
   zoom: number
   /**
    * Automatically sets the viewport coordinates such that the nodes are visible on screen. It is the equivalent of pressing Shift-1.
+   *
    */
   scrollAndZoomIntoView(nodes: ReadonlyArray<BaseNode>): void
   /**
    * The bounds of the viewport of the page that is currently visible on screen. The (x, y) corresponds to the top-left of the screen. User actions such as resizing the window or showing/hiding the rulers/UI will change the bounds of the viewport.
+   *
    */
   readonly bounds: Rect
   /**
@@ -3168,6 +3198,7 @@ interface ViewportAPI {
    * We have updated all of the create methods (`figma.createRectangle()`, `figma.createLine()`, etc) so that when the Figma Slides file is in Single Slide View,
    * they append that node to the focused slide instead of to the canvas. This is to ensure that the node you are creating is viewable by the current user and
    * not hidden off to the side of the larger grid view.
+   *
    */
   slidesView: 'grid' | 'single-slide'
   /**
@@ -3195,6 +3226,7 @@ interface ViewportAPI {
    * We have updated all of the create methods (`figma.createRectangle()`, `figma.createLine()`, etc) so that when the Figma Slides/Buzz file is in Asset View,
    * they append that node to the focused asset/slide instead of to the canvas. This is to ensure that the node you are creating is viewable by the current user and
    * not hidden off to the side of the larger grid view.
+   *
    */
   canvasView: 'grid' | 'single-asset'
 }
@@ -3330,14 +3362,17 @@ declare type ParameterInputEvent<ParametersType = ParameterValues> = {
 interface ParametersAPI {
   /**
    * Register a handler for user input events in the quick action UI.
+   *
    */
   on(type: 'input', callback: (event: ParameterInputEvent) => void): void
   /**
    * Register a handler for user input events in the quick action UI. Same as `figma.parameters.on("input")`, but only gets called the first time.
+   *
    */
   once(type: 'input', callback: (event: ParameterInputEvent) => void): void
   /**
    * Removes a handler added via `figma.parameters.on`.
+   *
    */
   off(type: 'input', callback: (event: ParameterInputEvent) => void): void
 }
@@ -3346,12 +3381,15 @@ interface ParametersAPI {
  */
 interface RunParametersEvent<ParametersType = ParameterValues | undefined> {
   command: string
+
   parameters: ParametersType
 }
 
 interface OpenDevResourcesEvent {
   command: 'open-dev-resource'
+
   parameters?: undefined
+
   link: {
     url: string
     name: string
@@ -3368,6 +3406,7 @@ interface SlidesViewChangeEvent {
  *
  * This event is triggered when users switch between Asset View and Grid View
  * in the Slides or Buzz interface, allowing plugins to respond to view changes.
+ *
  */
 interface CanvasViewChangeEvent {
   /**
@@ -3380,24 +3419,35 @@ interface CanvasViewChangeEvent {
 
 interface DropEvent {
   node: BaseNode | SceneNode
+
   x: number
+
   y: number
+
   absoluteX: number
+
   absoluteY: number
+
   items: DropItem[]
+
   files: DropFile[]
+
   dropMetadata?: any
 }
 
 interface DropItem {
   type: string
+
   data: string
 }
 
 interface DropFile {
   name: string
+
   type: string
+
   getBytesAsync(): Promise<Uint8Array>
+
   getTextAsync(): Promise<string>
 }
 
@@ -3514,6 +3564,7 @@ interface StyleDeleteChange extends BaseStyleChange {
    * The string literal "STYLE_DELETE" representing the type of document change this is. Always check the type before reading other properties. In this case, the returned style is null.
    */
   type: 'STYLE_DELETE'
+
   style: null
 }
 /**
@@ -5496,6 +5547,7 @@ interface BaseNodeMixin extends PluginDataMixin, DevResourcesMixin {
   readonly isAsset: boolean
   /**
    * Resolves to a JSON object of CSS properties of the node. This is the same CSS that Figma shows in the inspect panel and is helpful if you are building a [plugin for code generation](https://developers.figma.com/docs/plugins/codegen-plugins).
+   *
    */
   getCSSAsync(): Promise<{
     [key: string]: string
@@ -5581,6 +5633,7 @@ interface DevResourcesMixin {
    *
    * @param url - The url of the dev resource.
    * @param name - The name of the dev resource. If not provided, Figma will get the name from the url.
+   *
    */
   addDevResourceAsync(url: string, name?: string): Promise<void>
   /**
@@ -5589,6 +5642,7 @@ interface DevResourcesMixin {
    *
    * @param currentUrl - The current url of the dev resource.
    * @param newValue - The new name and/or url of the dev resource.
+   *
    */
   editDevResourceAsync(
     currentUrl: string,
@@ -7674,7 +7728,7 @@ interface ScatterBrushProperties {
   gap: number
   /** The amount of random movement applied to brush instances along the stroke path. The minimum value is 0. */
   wiggle: number
-  /** The amount of random size variation applied to brush instances. Ranges from 0 to 3.*/
+  /** The amount of random size variation applied to brush instances. Ranges from 0 to 3. */
   sizeJitter: number
   /** The amount of random angular variation in degrees applied to brush instances. Ranges from -180 to 180. */
   angularJitter: number
@@ -7721,11 +7775,11 @@ type BrushStrokeProperties = StretchBrushProperties | ScatterBrushProperties
 interface DynamicStrokeProperties {
   /** The type of complex stroke. Fixed to 'DYNAMIC'. */
   type: 'DYNAMIC'
-  /** The frequency of the dynamic stroke. Ranges from 0.01 to 20.*/
+  /** The frequency of the dynamic stroke. Ranges from 0.01 to 20. */
   frequency: number
-  /** The amplitude of the wiggles in the dynamic stroke. Minimum value is 0.*/
+  /** The amplitude of the wiggles in the dynamic stroke. Minimum value is 0. */
   wiggle: number
-  /** The amount of smoothing applied to the dynamic stroke. Ranges from 0 to 1.*/
+  /** The amount of smoothing applied to the dynamic stroke. Ranges from 0 to 1. */
   smoothen: number
 }
 /**
@@ -7808,15 +7862,19 @@ interface CornerMixin {
  */
 interface RectangleCornerMixin {
   /**
+   * The radius of the top left corner, in pixels. This value must be non-negative and can be fractional.
    */
   topLeftRadius: number
   /**
+   * The radius of the top right corner, in pixels. This value must be non-negative and can be fractional.
    */
   topRightRadius: number
   /**
+   * The radius of the bottom left corner, in pixels. This value must be non-negative and can be fractional.
    */
   bottomLeftRadius: number
   /**
+   * The radius of the bottom right corner, in pixels. This value must be non-negative and can be fractional.
    */
   bottomRightRadius: number
 }
@@ -7891,7 +7949,9 @@ interface ExportMixin {
    * ```
    */
   exportAsync(settings?: ExportSettings): Promise<Uint8Array>
+
   exportAsync(settings: ExportSettingsSVGString): Promise<string>
+
   exportAsync(settings: ExportSettingsREST): Promise<Object>
 }
 /**
@@ -8168,6 +8228,7 @@ interface PublishableMixin {
   readonly key: string
   /**
    * Gets the status of this style/component in the team library.
+   *
    */
   getPublishStatusAsync(): Promise<PublishStatus>
 }
@@ -8648,6 +8709,7 @@ interface ComponentPropertiesMixin {
    * - `defaultValue` is supported for `'BOOLEAN'`, `'TEXT'`, and `'INSTANCE_SWAP'` properties, but not for `'VARIANT'` or `'SLOT'` properties
    * - `preferredValues` is only supported for `'INSTANCE_SWAP'` and `'SLOT'` properties
    * - `description` is only supported for `'SLOT'` properties
+   * - `slotSettings` is only supported for `'SLOT'` properties
    */
   editComponentProperty(
     propertyName: string,
@@ -8656,6 +8718,7 @@ interface ComponentPropertiesMixin {
       defaultValue?: string | boolean | VariableAlias
       preferredValues?: InstanceSwapPreferredValue[]
       description?: string
+      slotSettings?: SlotSettings
     },
   ): string
   /**
@@ -9500,10 +9563,12 @@ interface PageNode
    * | [`CreateChange`](https://developers.figma.com/docs/plugins/api/NodeChange#createchange) | `'CREATE'` | A node has been created in the page. If a node with nested children is being added to the page a `CreateChange` will only be made for the highest level parent that was added to the page. |
    * | [`DeleteChange`](https://developers.figma.com/docs/plugins/api/NodeChange#deletechange) | `'DELETE'` | A node has been removed from the page. If a node with nested children is being removed from the page a  `DeleteChange`  will only be made for the highest level parent that was removed from the page. |
    * | [`PropertyChange`](https://developers.figma.com/docs/plugins/api/NodeChange#propertychange) | `'PROPERTY_CHANGE'` | A property of a node has changed. |
+   *
    */
   on(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
    * Same as {@link PageNode.on}, but the callback will only be called once, the first time the specified event happens.
+   *
    */
   once(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
@@ -9525,6 +9590,7 @@ interface PageNode
    * page.on("nodechange", () => { console.log("nodechange") })
    * page.off("nodechange", () => { console.log("nodechange") })
    * ```
+   *
    */
   off(type: 'nodechange', callback: (event: NodeChangeEvent) => void): void
   /**
@@ -9884,12 +9950,20 @@ type InstanceSwapPreferredValue = {
   type: 'COMPONENT' | 'COMPONENT_SET'
   key: string
 }
+type SlotSettings = {
+  stretchChildOnInsert?: boolean
+  displayEmptyByDefault?: boolean
+  minChildren?: number | null
+  maxChildren?: number | null
+  allowPreferredValuesOnly?: boolean
+}
 /**
  * @see https://developers.figma.com/docs/plugins/api/ComponentPropertyOptions
  */
 type ComponentPropertyOptions = {
   preferredValues?: InstanceSwapPreferredValue[]
   description?: string
+  slotSettings?: SlotSettings
 }
 /**
  * @see https://developers.figma.com/docs/plugins/api/ComponentPropertyDefinitions
@@ -9901,8 +9975,9 @@ type ComponentPropertyDefinitions = {
     preferredValues?: InstanceSwapPreferredValue[]
     variantOptions?: string[]
     description?: string
+    slotSettings?: SlotSettings
     readonly boundVariables?: {
-      [field in VariableBindableComponentPropertyField]?: VariableAlias
+      [field in VariableBindableComponentPropertyDefinitionField]?: VariableAlias
     }
   }
 }
@@ -10064,6 +10139,14 @@ interface SlotNode extends DefaultFrameMixin {
    * Resets a given slot node to the original component slot content.
    */
   resetSlot(): void
+  /**
+   * The set of limits, configured on the corresponding `'SLOT'` component property's {@link SlotSettings}, that the current contents of this slot violate. Returns an empty array when within limits. Multiple kinds may be present simultaneously (e.g. `['BELOW_MIN', 'HAS_NON_PREFERRED']`), since `HAS_NON_PREFERRED` is independent of the child count. `BELOW_MIN` and `ABOVE_MAX` are mutually exclusive.
+   *
+   * - `'BELOW_MIN'`: the slot has fewer children than its configured `minChildren`.
+   * - `'ABOVE_MAX'`: the slot has more children than its configured `maxChildren`.
+   * - `'HAS_NON_PREFERRED'`: the slot contains a child that is not in the property's preferred values, while `allowPreferredValuesOnly` is `true`.
+   */
+  readonly limitViolations: Array<'BELOW_MIN' | 'ABOVE_MAX' | 'HAS_NON_PREFERRED'>
 }
 interface BooleanOperationNode
   extends DefaultShapeMixin,
@@ -10129,6 +10212,7 @@ interface StampNode
    * if the stamp was created before July 2022 or if the user is currently not connected to the internet.
    *
    * `fileusers` must be specified in the permissions array in `manifest.json` to access this function.
+   *
    */
   getAuthorAsync(): Promise<BaseUser | null>
 }
@@ -10241,9 +10325,13 @@ interface TableCellNode extends MinimalFillsMixin {
    * The column index of this cell relative to its parent table.
    */
   readonly columnIndex: number
+
   readonly toString: string
+
   readonly parent: TableNode
+
   readonly height: number
+
   readonly width: number
 }
 interface HighlightNode
@@ -10871,6 +10959,7 @@ interface WidgetNode extends OpaqueNodeMixin, StickableMixin {
    * Caution: NOTE: every key in `syncedMapOverrides` will override the entire corresponding synced map, deleting all existing keys in the map. If you wish to preserve some of the keys in the map, you'll need to explicitly specify them in the override.
    *
    * For more information, check out [this page in our widget documentation](https://figma.com/widget-docs/managing-multiple-widgets#widgetnodeclonewidget).
+   *
    */
   cloneWidget(
     syncedStateOverrides: {
@@ -10894,6 +10983,7 @@ interface WidgetNode extends OpaqueNodeMixin, StickableMixin {
    * If you try to set the synced state for a widget with a different version of the same widget, that widget will automatically update to match the running widget's version. This ensures that the synced state values you set will always be compatible with the widget. A side effect of this is that a widget may get downgraded to a lower version.
    *
    * To get a list of other widgets with the same `widgetId`, check out [findWidgetNodesByWidgetId](https://developers.figma.com/docs/plugins/api/properties/nodes-findwidgetnodesbywidgetid).
+   *
    */
   setWidgetSyncedState(
     syncedState: {
@@ -11269,6 +11359,7 @@ interface BaseStyleMixin extends PublishableMixin, PluginDataMixin {
    * The unique identifier of the style in the document the plugin is executing from. You can assign this value via `setFillStyleIdAsync`, `setStrokeStyleIdAsync`, `setTextStyleIdAsync`, etc. to make the node properties reflect that of the style node.
    */
   readonly id: string
+
   readonly type: StyleType
   /**
    * The consumers of this style. The `fields` in `StyleConsumers` refers to the field where the style is applied (e.g. a PaintStyle can be applied in `setFillStyleIdAsync` or `setStrokeStyleIdAsync`).
@@ -11545,12 +11636,12 @@ interface FindAllCriteria<T extends NodeType[]> {
 /**
  * @see https://developers.figma.com/docs/plugins/api/TransformModifier
  */
-interface TransformModifier {}
+type TransformModifier = LinearRepeatModifier | RadialRepeatModifier
 /**
  * @see https://developers.figma.com/docs/plugins/api/TransformModifier
  * Base interface for repeat transform modifiers.
  */
-interface RepeatModifier extends TransformModifier {
+interface RepeatModifier {
   /** Type of transform modifier. Currently, only 'REPEAT' is supported. */
   type: 'REPEAT'
   /** Number of times to repeat the children. */


### PR DESCRIPTION
Update generated plugin typings (`plugin-api.d.ts` and `plugin-api-standalone.d.ts`).

## Changes

### Slot component properties
- Added new `SlotSettings` type with `stretchChildOnInsert`, `displayEmptyByDefault`, `minChildren`, `maxChildren`, and `allowPreferredValuesOnly` fields.
- Added optional `slotSettings` to component property options/definitions (only supported for `'SLOT'` properties).
- Added a readonly `limitViolations` property to `SlotNode` (`'BELOW_MIN' | 'ABOVE_MAX' | 'HAS_NON_PREFERRED'`) reporting which configured slot limits the current contents violate.
- Exported `SlotSettings`.

### Transform modifiers
- `TransformModifier` is now a union type (`LinearRepeatModifier | RadialRepeatModifier`) instead of an empty interface.
- `RepeatModifier` no longer extends `TransformModifier`.

### Variable binding
- Component property definition binding now uses `VariableBindableComponentPropertyDefinitionField` instead of `VariableBindableComponentPropertyField`.

### Docs / formatting
- Various JSDoc whitespace and formatting cleanups (added blank lines, fixed missing spaces before `*/` in brush/stroke comments, corner-radius doc text).