### PR TITLE
plugin-typings: Restore getCSSAsync to public typings

### DIFF
--- a/plugin-api-standalone.d.ts
+++ b/plugin-api-standalone.d.ts
@@ -6250,6 +6250,13 @@ interface BaseNodeMixin extends PluginDataMixin, DevResourcesMixin {
    */
   readonly isAsset: boolean
   /**
+   * Resolves to a JSON object of CSS properties of the node. This is the same CSS that Figma shows in the inspect panel and is helpful if you are building a [plugin for code generation](https://developers.figma.com/docs/plugins/codegen-plugins).
+   *
+   */
+  getCSSAsync(): Promise<{
+    [key: string]: string
+  }>
+  /**
    * Returns the top-most frame that contains this node. If the node is not inside a frame, this will return undefined.
    *
    * Note: This function will only work in Figma Design and will throw an error if called in FigJam or Slides.

--- a/plugin-api.d.ts
+++ b/plugin-api.d.ts
@@ -6250,6 +6250,13 @@ interface BaseNodeMixin extends PluginDataMixin, DevResourcesMixin {
    */
   readonly isAsset: boolean
   /**
+   * Resolves to a JSON object of CSS properties of the node. This is the same CSS that Figma shows in the inspect panel and is helpful if you are building a [plugin for code generation](https://developers.figma.com/docs/plugins/codegen-plugins).
+   *
+   */
+  getCSSAsync(): Promise<{
+    [key: string]: string
+  }>
+  /**
    * Returns the top-most frame that contains this node. If the node is not inside a frame, this will return undefined.
    *
    * Note: This function will only work in Figma Design and will throw an error if called in FigJam or Slides.


### PR DESCRIPTION
Summary
- Regenerate the public Plugin API typings from figma/figma master.
- Restore BaseNodeMixin.getCSSAsync, which remained available at runtime but was unintentionally omitted from the generated public declarations.

Source
- https://github.com/figma/figma/pull/922757

Test plan
- npm test
- npm run prettier:check
- Generated with pnpm update-typings from figma/figma at 3aa97743bb49.